### PR TITLE
fix shared lib not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ FIND_PACKAGE(DGtal 0.9.1 REQUIRED)
 INCLUDE_DIRECTORIES(${DGTAL_INCLUDE_DIRS})
 LINK_DIRECTORIES(${DGTAL_LIBRARY_DIRS})
 
+
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
  # -------------------------------------------------------------------------
  # This test is for instance used for ITK v3.x. ITK forces a limited
  # template depth. We remove this option.


### PR DESCRIPTION
Small PR to fix a lib search of tools when installed.
See doc https://cmake.org/Wiki/CMake_RPATH_handling, "Common questions" sections.
It resolves a pb that I detect few time ago... 
