### PR TITLE
Sphere display with various sizes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,12 @@
-# DGtalTools 0.9.2 
+# DGtalTools 0.9.2
 
-# DGtalTools 0.9.1 
+- *visualisation*:
+  - 3dSDPViewer: add the possibility to display a set of point by using
+    different ball size (specified in the input sdp file) (B. Kerautret).
+
+
+
+# DGtalTools 0.9.1
 
 - *converters*:
   - img2freeman: new option to sort the resulting contours by increasing size

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 - *visualisation*:
   - 3dSDPViewer: add the possibility to display a set of point by using
-    different ball size (specified in the input sdp file) (B. Kerautret).
+    different sphere sizes (specified in the input sdp file) (B. Kerautret).
 
 
 


### PR DESCRIPTION
# PR Description
With the option --sphereRadiusFromInput we can customize the size of each sdp point if displayed with sphere primitive (4th column).


# Checklist

- [n.a ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [n.a] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
