### PR TITLE
Fix temporary uses when ConstAlias needed.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # DGtalTools 0.9.2 
 
+- *global*:
+  - fix uses of temporaries when ConstAlias is needed.
+    (Roland Denis, [#253](https://github.com/DGtal-team/DGtalTools/pull/253))
+
 # DGtalTools 0.9.1 
 
 - *converters*:

--- a/converters/vol2slice.cpp
+++ b/converters/vol2slice.cpp
@@ -128,7 +128,8 @@ int main( int argc, char** argv )
     DGtal::Z2i::Domain domain2D(invFunctor(input3dImage.domain().lowerBound()),
   				invFunctor(input3dImage.domain().upperBound()));
     DGtal::functors::Projector<DGtal::Z3i::Space> aSliceFunctor(i); aSliceFunctor.initAddOneDim(sliceOrientation);
-    SliceImageAdapter sliceImage(input3dImage, domain2D, aSliceFunctor, DGtal::functors::Identity());
+    const DGtal::functors::Identity identityFunctor{};
+    SliceImageAdapter sliceImage( input3dImage, domain2D, aSliceFunctor, identityFunctor );
     stringstream outName; outName << outputBasename << "_" <<  boost::format("%|05|")% i <<"."<< outputExt ;
     trace.info() << ": "<< outName.str() ;
     GenericWriter<SliceImageAdapter>::exportFile(outName.str(), sliceImage);

--- a/estimators/generic3dNormalEstimators.cpp
+++ b/estimators/generic3dNormalEstimators.cpp
@@ -516,7 +516,8 @@ int chooseSurface
       typedef typename Surface::Surfel Surfel;
       SurfelAdjacency< KSpace::dimension > surfAdj( true );
       Surfel bel;
-      KanungoPredicate* noisified_dshape = new KanungoPredicate( dshape, dshape.getDomain(), noiseLevel );
+      const Domain shapeDomain = dshape.getDomain();
+      KanungoPredicate* noisified_dshape = new KanungoPredicate( dshape, shapeDomain, noiseLevel );
       // We have to search for a big connected component.
       CountedPtr<Surface> ptrSurface;
       double minsize = dshape.getUpperBound()[0] - dshape.getLowerBound()[0];

--- a/visualisation/3dCurvatureViewer.cpp
+++ b/visualisation/3dCurvatureViewer.cpp
@@ -265,7 +265,8 @@ int main( int argc, char** argv )
   DGtal::functors::BasicDomainSubSampler< HyperRectDomain< SpaceND< 3, int > >,
                                           DGtal::int32_t, double > reSampler(image.domain(),
                                                                              aGridSizeReSample,  shiftVector3D);
-  SamplerImageAdapter sampledImage (image, reSampler.getSubSampledDomain(), reSampler, functors::Identity());
+  const functors::Identity identityFunctor{};
+  SamplerImageAdapter sampledImage ( image, reSampler.getSubSampledDomain(), reSampler, identityFunctor );
   ImagePredicate predicateIMG = ImagePredicate( sampledImage,  minImageThreshold, maxImageThreshold );
   DomainPredicate<Z3i::Domain> domainPredicate( sampledImage.domain() );
   AndBoolFct2 andF;

--- a/visualisation/3dCurvatureViewerNoise.cpp
+++ b/visualisation/3dCurvatureViewerNoise.cpp
@@ -277,7 +277,8 @@ int main( int argc, char** argv )
   DGtal::functors::BasicDomainSubSampler< HyperRectDomain< SpaceND< 3, int > >,
                                           DGtal::int32_t, double > reSampler(image.domain(),
                                                                              aGridSizeReSample,  shiftVector3D);
-  SamplerImageAdapter sampledImage (image, reSampler.getSubSampledDomain(), reSampler, functors::Identity());
+  const functors::Identity identityFunctor{};
+  SamplerImageAdapter sampledImage ( image, reSampler.getSubSampledDomain(), reSampler, identityFunctor );
   ImagePredicate predicateIMG = ImagePredicate( sampledImage,  minImageThreshold, maxImageThreshold );
   KanungoPredicate noisifiedPredicateIMG( predicateIMG, sampledImage.domain(), noiseLevel );
   DomainPredicate<Z3i::Domain> domainPredicate( sampledImage.domain() );

--- a/visualisation/sliceViewer.cpp
+++ b/visualisation/sliceViewer.cpp
@@ -253,7 +253,8 @@ void MainWindow::updateZoomImageX(unsigned int sliceNumber, double gridSize){
   DGtal::Z2i::Domain domain2D(invFunctor(myImage3D->domain().lowerBound()),
                               invFunctor(myImage3D->domain().upperBound()));
   DGtal::functors::Projector<DGtal::Z3i::Space> aSliceFunctor(sliceNumber); aSliceFunctor.initAddOneDim(0);
-  SliceImageAdapter sliceImage(*myImage3D, domain2D, aSliceFunctor, functors::Identity());
+  const functors::Identity identityFunctor{};
+  SliceImageAdapter sliceImage( *myImage3D, domain2D, aSliceFunctor, identityFunctor );
   QImage anImage = getImage(sliceImage, gridSize, myColorMap);
   setImageProjX(QPixmap::fromImage(anImage));
 }
@@ -263,7 +264,8 @@ void MainWindow::updateZoomImageY(unsigned int sliceNumber, double gridSize){
   DGtal::Z2i::Domain domain2D(invFunctor(myImage3D->domain().lowerBound()),
                               invFunctor(myImage3D->domain().upperBound()));
   DGtal::functors::Projector<DGtal::Z3i::Space> aSliceFunctor(sliceNumber); aSliceFunctor.initAddOneDim(1);
-  SliceImageAdapter sliceImage(*myImage3D, domain2D, aSliceFunctor, functors::Identity());
+  const functors::Identity identityFunctor{};
+  SliceImageAdapter sliceImage( *myImage3D, domain2D, aSliceFunctor, identityFunctor );
 
   QImage anImage = getImage(sliceImage, gridSize, myColorMap);
   setImageProjY(QPixmap::fromImage(anImage));
@@ -275,7 +277,8 @@ void MainWindow::updateZoomImageZ(unsigned int sliceNumber, double gridSize){
   DGtal::Z2i::Domain domain2D(invFunctor(myImage3D->domain().lowerBound()),
                               invFunctor(myImage3D->domain().upperBound()));
   DGtal::functors::Projector<DGtal::Z3i::Space> aSliceFunctor(sliceNumber); aSliceFunctor.initAddOneDim(2);
-  SliceImageAdapter sliceImage(*myImage3D, domain2D, aSliceFunctor, functors::Identity());
+  const functors::Identity identityFunctor{};
+  SliceImageAdapter sliceImage( *myImage3D, domain2D, aSliceFunctor, identityFunctor );
   QImage anImage = getImage(sliceImage, gridSize, myColorMap );
   setImageProjZ(QPixmap::fromImage(anImage));
 }
@@ -286,7 +289,8 @@ void MainWindow::updateSliceImageX(int sliceNumber, bool init){
   DGtal::Z2i::Domain domain2D(invFunctor(myImage3D->domain().lowerBound()),
                               invFunctor(myImage3D->domain().upperBound()));
   DGtal::functors::Projector<DGtal::Z3i::Space> aSliceFunctor(sliceNumber); aSliceFunctor.initAddOneDim(0);
-  SliceImageAdapter sliceImage (*myImage3D, domain2D, aSliceFunctor, functors::Identity());
+  const functors::Identity identityFunctor{};
+  SliceImageAdapter sliceImage ( *myImage3D, domain2D, aSliceFunctor, identityFunctor );
   
   double gridSize = ((double)INIT_SCALE1_ZOOM_FACTOR)/ui->_zoomXSlider->value();
   QImage anImage = getImage(sliceImage, gridSize,myColorMap);
@@ -316,7 +320,8 @@ void MainWindow::updateSliceImageY( int sliceNumber, bool init){
   DGtal::Z2i::Domain domain2D(invFunctor(myImage3D->domain().lowerBound()),
                               invFunctor(myImage3D->domain().upperBound()));
   DGtal::functors::Projector<DGtal::Z3i::Space> aSliceFunctor(sliceNumber); aSliceFunctor.initAddOneDim(1);
-  SliceImageAdapter sliceImage(*myImage3D, domain2D, aSliceFunctor, functors::Identity());
+  const functors::Identity identityFunctor{};
+  SliceImageAdapter sliceImage( *myImage3D, domain2D, aSliceFunctor, identityFunctor );
   
   double gridSize = ((double)INIT_SCALE1_ZOOM_FACTOR)/ui->_zoomYSlider->value();
   QImage anImage = getImage(sliceImage, gridSize, myColorMap);
@@ -344,7 +349,8 @@ void MainWindow::updateSliceImageZ(int sliceNumber, bool init){
   DGtal::Z2i::Domain domain2D(invFunctor(myImage3D->domain().lowerBound()),
                               invFunctor(myImage3D->domain().upperBound()));
   DGtal::functors::Projector<DGtal::Z3i::Space> aSliceFunctor(sliceNumber); aSliceFunctor.initAddOneDim(2);
-  SliceImageAdapter sliceImage(*myImage3D, domain2D, aSliceFunctor, functors::Identity());
+  const functors::Identity identityFunctor{};
+  SliceImageAdapter sliceImage( *myImage3D, domain2D, aSliceFunctor, identityFunctor );
   double gridSize = (double)INIT_SCALE1_ZOOM_FACTOR/ui->_zoomZSlider->value();
   QImage anImage = getImage(sliceImage, gridSize, myColorMap);
   setImageProjZ(QPixmap::fromImage(anImage));

--- a/visualisation/specificClasses/Viewer3DImage.cpp
+++ b/visualisation/specificClasses/Viewer3DImage.cpp
@@ -84,7 +84,8 @@ Viewer3DImage< Space, KSpace>::setVolImage(Image3D * an3DImage){
   
     
   DGtal::functors::SliceRotator2D<DGtal::Z3i::Domain> aSliceFunctorX(0, my3dImage->domain(), mySliceXPos,2, myAngleRotation );
-  MyRotatorSliceImageAdapter sliceImageX(*my3dImage, domain2DX, aSliceFunctorX, DGtal::functors::Identity()); 
+  const DGtal::functors::Identity identityFunctor{};
+  MyRotatorSliceImageAdapter sliceImageX( *my3dImage, domain2DX, aSliceFunctorX, identityFunctor ); 
     
   std::cout << "image:" << sliceImageX.className();
   (*this) << sliceImageX;
@@ -97,7 +98,7 @@ Viewer3DImage< Space, KSpace>::setVolImage(Image3D * an3DImage){
 			       invFunctorY(my3dImage->domain().upperBound()));
  
   DGtal::functors::Projector<DGtal::Z3i::Space> aSliceFunctorY(mySliceYPos); aSliceFunctorY.initAddOneDim(1);
-  SliceImageAdapter sliceImageY(*my3dImage, domain2DY, aSliceFunctorY, DGtal::functors::Identity()); 
+  SliceImageAdapter sliceImageY(*my3dImage, domain2DY, aSliceFunctorY, identityFunctor ); 
   (*this) << sliceImageY;
   (*this) << DGtal::UpdateImagePosition< Space, KSpace >(1, DGtal::Viewer3D<>::yDirection, myImageOrigin[0], mySliceYPos, myImageOrigin[2]);
 
@@ -113,7 +114,7 @@ Viewer3DImage< Space, KSpace>::setVolImage(Image3D * an3DImage){
   DGtal::Z3i::Point centerZ((my3dImage->domain().upperBound())[0]/2, (my3dImage->domain().upperBound())[1]/2, mySliceZPos);
     
   DGtal::functors::SliceRotator2D<DGtal::Z3i::Domain> aSliceFunctorZ(2, my3dImage->domain(), mySliceZPos, 2, myAngleRotation, centerZ );
-  MyRotatorSliceImageAdapter sliceImageZ(*my3dImage, domain2DZ, aSliceFunctorZ, DGtal::functors::Identity()); 
+  MyRotatorSliceImageAdapter sliceImageZ( *my3dImage, domain2DZ, aSliceFunctorZ, identityFunctor ); 
   (*this) << sliceImageZ;
   (*this) << DGtal::UpdateImagePosition< Space, KSpace > (2, DGtal::Viewer3D<>::zDirection, myImageOrigin[0], myImageOrigin[1], mySliceZPos);
 
@@ -239,8 +240,9 @@ Viewer3DImage< Space, KSpace>::keyPressEvent ( QKeyEvent *e )
       DGtal::functors::Projector<DGtal::Z2i::Space>  invFunctor; invFunctor.initRemoveOneDim(myCurrentSliceDim);
       DGtal::Z2i::Domain domain2D(invFunctor(my3dImage->domain().lowerBound()), 
 				  invFunctor(my3dImage->domain().upperBound()));
-      
-      MyRotatorSliceImageAdapter sliceImage(*my3dImage, domain2D, aSliceFunctor, DGtal::functors::Identity()); 
+     
+      const DGtal::functors::Identity identityFunctor{};
+      MyRotatorSliceImageAdapter sliceImage( *my3dImage, domain2D, aSliceFunctor, identityFunctor ); 
       
       (*this) << DGtal::UpdateImageData<MyRotatorSliceImageAdapter>(myCurrentSliceDim, sliceImage, 
                                                                    (myCurrentSliceDim==0)? dirStep: 0.0, 

--- a/volumetric/homotopicThinning3D.cpp
+++ b/volumetric/homotopicThinning3D.cpp
@@ -124,7 +124,8 @@ int main( int argc, char** argv )
   typedef functors::IntervalForegroundPredicate<Image> Predicate;
   Predicate aPredicate(image, vm[ "min" ].as<int>(), vm[ "max" ].as<int>() );
 
-  DistanceTransformation<Z3i::Space, Predicate , Z3i::L2Metric> dt(image.domain(),aPredicate, Z3i::L2Metric() );
+  const Z3i::L2Metric aMetric{};
+  DistanceTransformation<Z3i::Space, Predicate , Z3i::L2Metric> dt(image.domain(), aPredicate, aMetric );
   trace.endBlock();
   trace.info() <<image<<std::endl;
 

--- a/volumetric/volReSample.cpp
+++ b/volumetric/volReSample.cpp
@@ -116,7 +116,9 @@ int main( int argc, char** argv )
   DGtal::functors::BasicDomainSubSampler< HyperRectDomain<SpaceND<3, int> >,  
                                           DGtal::int32_t, double > reSampler(input3dImage.domain(),
                                                                              aGridSizeReSample,  shiftVector3D);  
-  SamplerImageAdapter sampledImage (input3dImage,reSampler.getSubSampledDomain(), reSampler, functors::Identity());
+
+  const functors::Identity aFunctor{};
+  SamplerImageAdapter sampledImage ( input3dImage, reSampler.getSubSampledDomain(), reSampler, aFunctor );
   GenericWriter<SamplerImageAdapter>::exportFile(outputFileName, sampledImage);
   
 

--- a/volumetric/volShapeMetrics.cpp
+++ b/volumetric/volShapeMetrics.cpp
@@ -75,8 +75,9 @@ getStatsFromDistanceMap(Statistic<double> & stats, const Image3D &imageA, int aM
   
 
   // Applying the distance transform on the digital surface of the set: 
-  typedef  DistanceTransformation<Z3i::Space, NegPredicate, Z3i::L2Metric> DTL2;   
-  DTL2 dtL2(&(imageA.domain()), NegPredicate(set3dRef), &Z3i::l2Metric);
+  typedef  DistanceTransformation<Z3i::Space, NegPredicate, Z3i::L2Metric> DTL2;
+  const NegPredicate aPredicate( set3dRef );
+  DTL2 dtL2( imageA.domain(), aPredicate, Z3i::l2Metric );
 
   // Get the set of point of imageB: (use -1 and +1 since the interval of append function are open)
   Z3i::DigitalSet set3dComp (imageB.domain()); 


### PR DESCRIPTION
# PR Description

Fix temporary uses when ConstAlias is needed. It is related to DGtal-team/DGtal#1140 and DGtal-team/DGtal#1141

# Checklist

- [N/A] Doxygen documentation of the code completed (classes, methods, types, members...)
- [N/A] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [N/A] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
