### PR TITLE
Fix sliceViewer

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@
   - fix uses of temporaries when ConstAlias is needed.
     (Roland Denis, [#253](https://github.com/DGtal-team/DGtalTools/pull/253))
 
+- *visualisation*:
+  - sliceViewer: fix bug when imported image domain doesn't contain (0,0,0) point.
+    (Roland Denis, [#256](https://github.com/DGtal-team/DGtalTools/pull/256))
+
 - *volumetric*:
   - fix reading options bug in volCComponentCounter and sdp2vol.
     (Bertrand Kerautret,

--- a/visualisation/sliceViewer.cpp
+++ b/visualisation/sliceViewer.cpp
@@ -251,7 +251,7 @@ void MainWindow::updateZoomImageZ(){
 }
 
 
-void MainWindow::updateZoomImageX(unsigned int sliceNumber, double gridSize){
+void MainWindow::updateZoomImageX(int sliceNumber, double gridSize){
   DGtal::functors::Projector<DGtal::Z2i::Space>  invFunctor; invFunctor.initRemoveOneDim(0);
   DGtal::Z2i::Domain domain2D(invFunctor(myImage3D->domain().lowerBound()),
                               invFunctor(myImage3D->domain().upperBound()));
@@ -262,7 +262,7 @@ void MainWindow::updateZoomImageX(unsigned int sliceNumber, double gridSize){
   setImageProjX(QPixmap::fromImage(anImage));
 }
 
-void MainWindow::updateZoomImageY(unsigned int sliceNumber, double gridSize){
+void MainWindow::updateZoomImageY(int sliceNumber, double gridSize){
   DGtal::functors::Projector<DGtal::Z2i::Space>  invFunctor; invFunctor.initRemoveOneDim(1);
   DGtal::Z2i::Domain domain2D(invFunctor(myImage3D->domain().lowerBound()),
                               invFunctor(myImage3D->domain().upperBound()));
@@ -275,7 +275,7 @@ void MainWindow::updateZoomImageY(unsigned int sliceNumber, double gridSize){
 }
 
 
-void MainWindow::updateZoomImageZ(unsigned int sliceNumber, double gridSize){
+void MainWindow::updateZoomImageZ(int sliceNumber, double gridSize){
   DGtal::functors::Projector<DGtal::Z2i::Space>  invFunctor; invFunctor.initRemoveOneDim(2);
   DGtal::Z2i::Domain domain2D(invFunctor(myImage3D->domain().lowerBound()),
                               invFunctor(myImage3D->domain().upperBound()));

--- a/visualisation/sliceViewer.cpp
+++ b/visualisation/sliceViewer.cpp
@@ -109,6 +109,31 @@ MainWindow::MainWindow(DGtal::Viewer3D<> *aViewer,
   ui->setupUi(this);
   ui->verticalLayout_5->addWidget(aViewer);
 
+
+  ui->_horizontalSliderZ->setMinimum(anImage->domain().lowerBound()[2]);
+  ui->_horizontalSliderZ->setMaximum(anImage->domain().upperBound()[2]);
+  ui->_horizontalSliderZ->setValue(anImage->domain().lowerBound()[2]);
+
+  ui->_horizontalSliderY->setMinimum(anImage->domain().lowerBound()[1]);
+  ui->_horizontalSliderY->setMaximum(anImage->domain().upperBound()[1]);
+  ui->_horizontalSliderY->setValue(anImage->domain().lowerBound()[1]);
+
+  ui->_horizontalSliderX->setMinimum(anImage->domain().lowerBound()[0]);
+  ui->_horizontalSliderX->setMaximum(anImage->domain().upperBound()[0]);
+  ui->_horizontalSliderX->setValue(anImage->domain().lowerBound()[0]);
+
+  ui->_zoomXSlider->setMinimum( MIN_ZOOM_FACTOR);
+  ui->_zoomXSlider->setMaximum( MAX_ZOOM_FACTOR);
+  ui->_zoomXSlider->setValue(INIT_SCALE1_ZOOM_FACTOR);
+
+  ui->_zoomYSlider->setMinimum(MIN_ZOOM_FACTOR);
+  ui->_zoomYSlider->setMaximum(MAX_ZOOM_FACTOR);
+  ui->_zoomYSlider->setValue(INIT_SCALE1_ZOOM_FACTOR);
+
+  ui->_zoomZSlider->setMinimum(MIN_ZOOM_FACTOR);
+  ui->_zoomZSlider->setMaximum(MAX_ZOOM_FACTOR);
+  ui->_zoomZSlider->setValue(INIT_SCALE1_ZOOM_FACTOR);
+
   QObject::connect(ui->_horizontalSliderX, SIGNAL(valueChanged(int)), this, SLOT(updateSliceImageX()));
   QObject::connect(ui->_horizontalSliderY, SIGNAL(valueChanged(int)), this, SLOT(updateSliceImageY()));
   QObject::connect(ui->_horizontalSliderZ, SIGNAL(valueChanged(int)), this, SLOT(updateSliceImageZ()));
@@ -124,28 +149,6 @@ MainWindow::MainWindow(DGtal::Viewer3D<> *aViewer,
   QObject::connect(ui->_HotButton, SIGNAL(clicked()), this, SLOT(changeHotColorMap()));
   QObject::connect(ui->_HueButton, SIGNAL(clicked()), this, SLOT(changeHueColorMap()));
   QObject::connect(ui->_NormalButton, SIGNAL(clicked()), this, SLOT(changeNormalColorMap()));
-
-  ui->_horizontalSliderZ->setMinimum(anImage->domain().lowerBound()[2]);
-  ui->_horizontalSliderZ->setMaximum(anImage->domain().upperBound()[2]);
-
-  ui->_horizontalSliderY->setMinimum(anImage->domain().lowerBound()[1]);
-  ui->_horizontalSliderY->setMaximum(anImage->domain().upperBound()[1]);
-
-  ui->_horizontalSliderX->setMinimum(anImage->domain().lowerBound()[0]);
-  ui->_horizontalSliderX->setMaximum(anImage->domain().upperBound()[0]);
-
-  ui->_zoomXSlider->setMinimum( MIN_ZOOM_FACTOR);
-  ui->_zoomXSlider->setMaximum( MAX_ZOOM_FACTOR);
-  ui->_zoomXSlider->setValue(INIT_SCALE1_ZOOM_FACTOR);
-
-  ui->_zoomYSlider->setMinimum(MIN_ZOOM_FACTOR);
-  ui->_zoomYSlider->setMaximum(MAX_ZOOM_FACTOR);
-  ui->_zoomYSlider->setValue(INIT_SCALE1_ZOOM_FACTOR);
-
-  ui->_zoomZSlider->setMinimum(MIN_ZOOM_FACTOR);
-  ui->_zoomZSlider->setMaximum(MAX_ZOOM_FACTOR);
-  ui->_zoomZSlider->setValue(INIT_SCALE1_ZOOM_FACTOR);
-
   
 
 }
@@ -464,15 +467,15 @@ int main( int argc, char** argv )
                                                              usegc? MainWindow::GradientMapCool:
                                                              MainWindow::Id), 0,0);
     w.setWindowTitle ( QString("sliceViewer"));
-    w.updateSliceImageX(0, true);
-    w.updateSliceImageY(0, true);
-    w.updateSliceImageZ(0, true);
+    w.updateSliceImageX( image.domain().lowerBound()[0], true);
+    w.updateSliceImageY( image.domain().lowerBound()[1], true);
+    w.updateSliceImageZ( image.domain().lowerBound()[2], true);
     w.show();
     Z3i::Point size = image.domain().upperBound() - image.domain().lowerBound();
     Z3i::Point center = image.domain().lowerBound()+size/2;
     unsigned int maxDist = std::max(std::max(size[2], size[1]), size[2]);
     viewer->camera()->setPosition(qglviewer::Vec(center[0],center[1], 
-                                                 2.0*maxDist));
+                                                 center[2] + 2.0*maxDist));
     viewer->camera()->setSceneCenter(qglviewer::Vec(center[0],center[1],center[2]));
     application.exec();
     delete viewer;

--- a/visualisation/sliceViewer.h
+++ b/visualisation/sliceViewer.h
@@ -112,9 +112,9 @@ public:
   void updateSliceImageY( int sliceNumber, bool init);
   void updateSliceImageZ( int sliceNumber, bool init);
 
-  void updateZoomImageX(unsigned int sliceNumber, double gridSize);
-  void updateZoomImageY(unsigned int sliceNumber, double gridSize);
-  void updateZoomImageZ(unsigned int sliceNumber, double gridSize);
+  void updateZoomImageX(int sliceNumber, double gridSize);
+  void updateZoomImageY(int sliceNumber, double gridSize);
+  void updateZoomImageZ(int sliceNumber, double gridSize);
   void updateAllDisplayedImages();                                                                 
                                                                   
 


### PR DESCRIPTION
# PR Description

Fixing `sliceViewer` bug that cause assert failure and exception raise when the imported image domain doesn't contain the `(0,0,0)` point (like the example file provided in #255).

# Checklist

- [N/A] Doxygen documentation of the code completed (classes, methods, types, members...)
- [N/A] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [N/A] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
