### PR TITLE
add selection 3dSDPViewer

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@
 - *visualisation*:
   - sliceViewer: fix bug when imported image domain doesn't contain (0,0,0) point.
     (Roland Denis, [#256](https://github.com/DGtal-team/DGtalTools/pull/256))
+  - 3dSDPViewer: add an option to display on screen the selected voxel.
+    (Bertrand Kerautret,
+    [#257](https://github.com/DGtal-team/DGtalTools/pull/257))
+
 
 - *volumetric*:
   - fix reading options bug in volCComponentCounter and sdp2vol.

--- a/visualisation/3dSDPViewer.cpp
+++ b/visualisation/3dSDPViewer.cpp
@@ -58,7 +58,7 @@ typedef Viewer3D<Z3i::Space, Z3i::KSpace> Viewer;
 
 // call back function to display voxel coordinates 
 int 
-displayCoordsCallBack( void* viewer, int32_t name, void* data )
+displayCoordsCallBack( void* viewer, DGtal::int32_t name, void* data )
 {
   vector<Z3i::RealPoint> *vectVoxels = (vector<Z3i::RealPoint> *) data;
   std::stringstream ss;

--- a/visualisation/3dSDPViewer.cpp
+++ b/visualisation/3dSDPViewer.cpp
@@ -58,7 +58,7 @@ typedef Viewer3D<Z3i::Space, Z3i::KSpace> Viewer;
 
 // call back function to display voxel coordinates 
 int 
-displayCoordsCallBack( void* viewer, DGtal::int32_t name, void* data )
+displayCoordsCallBack( void* viewer, int name, void* data )
 {
   vector<Z3i::RealPoint> *vectVoxels = (vector<Z3i::RealPoint> *) data;
   std::stringstream ss;


### PR DESCRIPTION
# PR Description
Add an option to be able to select a voxel and display its coordinates:
./visualisation/3dSDPViewer -i test.sdp  --interactiveDisplayVoxCoords

<img width="912" alt="capture d ecran 2016-04-22 a 09 24 25" src="https://cloud.githubusercontent.com/assets/772865/14734836/76b53ff0-086d-11e6-8809-4620db770ab3.png">

# Checklist

- [na.] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [na. ] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).

