### PR TITLE
fix colors in 3dSDPViewer

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,10 @@
   - renaming of the shapeGenerator folder to generators (David Coeurjolly, [#268](https://github.com/DGtal-team/DGtalTools/pull/268)))
 
 - *visualisation*:
+  - 3dSDPViewer: fix the mesh display which was not given with their original 
+   colors. (Bertrand Kerautret,
+   [#272](https://github.com/DGtal-team/DGtalTools/pull/272))
+
   - 3dSDPViewer: add the possibility to display a set of point by using
     different sphere sizes (specified in the input sdp file).
    (Bertrand Kerautret,

--- a/visualisation/3dSDPViewer.cpp
+++ b/visualisation/3dSDPViewer.cpp
@@ -428,19 +428,16 @@ int main( int argc, char** argv )
     }
     if(vm.count("addMesh"))
     {
-      DGtal::Color meshColor = DGtal::Color::White;
-      if(vm.count("customColorMesh")){
+      bool customColorMesh =  vm.count("customColorMesh");
+      if(customColorMesh){
         std::vector<unsigned int > vectCol = vm["customColorMesh"].as<std::vector<unsigned int> >();
         if(vectCol.size()!=4){
           trace.error() << "colors specification should contain R,G,B and Alpha values"<< std::endl;
         }
-        meshColor = DGtal::Color(vectCol[0], vectCol[1], vectCol[2], vectCol[3]);
-       }
-      viewer.setFillColor(meshColor);
-
-
+        viewer.setFillColor(DGtal::Color(vectCol[0], vectCol[1], vectCol[2], vectCol[3]));
+      }
       std::string meshName = vm["addMesh"].as<std::string>();
-      Mesh<Z3i::RealPoint> mesh;
+      Mesh<Z3i::RealPoint> mesh(!customColorMesh);
       mesh << meshName ;
       viewer << mesh;
     }


### PR DESCRIPTION
# PR Description
The mesh display was always displayed in white instead their original colors.

# Checklist
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
