### PR TITLE
fix itk2vol tools when reading int values

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,10 @@
+# DGtalTools 0.9.3
+
+- *converters*:
+   - fix tool itk2vol which was not able to read and convert int type image.
+   (Bertrand Kerautret, [#276](https://github.com/DGtal-team/DGtalTools/pull/271))
+
+
 # DGtalTools 0.9.2
 
 - *global*:

--- a/converters/itk2vol.cpp
+++ b/converters/itk2vol.cpp
@@ -74,8 +74,8 @@ namespace po = boost::program_options;
 
 int main( int argc, char** argv )
 {
-  typedef ImageContainerBySTLVector < Z3i::Domain, unsigned char > Image3D;
-
+  typedef ImageContainerBySTLVector < Z3i::Domain, unsigned char > Image3DChar;
+  typedef ImageContainerBySTLVector < Z3i::Domain,  int > Image3D;
   
   // parse command line ----------------------------------------------
   po::options_description general_opt("Allowed options are ");
@@ -103,7 +103,7 @@ int main( int argc, char** argv )
 		<< "Converts itk file into a volumetric file (.vol, .pgm3d). "
 		<< general_opt << "\n";
       std::cout << "Example:\n"
-		<< "itk2vol -i image.mhd --dicomMin -500 --dicomMax -100 -o sample.vol \n";
+		<< "itk2vol -i image.mhd --inputMin -500 --inputMax -100 -o sample.vol \n";
       return 0;
     }
   
@@ -121,12 +121,14 @@ int main( int argc, char** argv )
   typedef DGtal::functors::Rescaling<int ,unsigned char > RescalFCT;
   
   trace.info() << "Reading input input file " << inputFilename ; 
-  Image3D inputImage = ITKReader< Image3D,  RescalFCT  >::importITK(inputFilename, 
-                                                                      RescalFCT(inputMin, 
-                                                                                inputMax, 0, 255) );
+  Image3D inputImage = ITKReader< Image3D  >::importITK(inputFilename);
   trace.info() << " [done] " << std::endl ; 
   trace.info() << " converting into vol file... " ; 
-  inputImage >> outputFilename; 
+  RescalFCT rescaleCustom(inputMin, inputMax, 0, 255);
+
+  DGtal::GenericWriter<Image3D, 3, unsigned char, RescalFCT>::exportFile(outputFilename, inputImage, "UInt8Array3D", rescaleCustom);
+  
+
   trace.info() << " [done] " << std::endl ;   
 
 


### PR DESCRIPTION
# PR Description
Fix a problem when reading itk image containing not unsigned char types. 
The resulting read was always considering the itk input as unsigned char...
By putting the scale functor after the read all looks fine...

# Checklist

- [na] Doxygen documentation of the code completed (classes, methods, types, members...).
- [na] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [na] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [na] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
