### PR TITLE
add snapshot option 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,8 +9,9 @@
 - *visualisation*: 
    - Add SnapShot option for meshViewer and 3dVolViewer 
      (useful to get visualisation without interaction like for scripting and/or 
-     online demonstration)
-   (Bertrand Kerautret, [#282](https://github.com/DGtal-team/DGtalTools/pull/282))
+     online demonstration). It also contains a new option to display a mesh in 
+     3DvolViewer. 
+     (Bertrand Kerautret, [#282](https://github.com/DGtal-team/DGtalTools/pull/282))
 
 
 # DGtalTools 0.9.2

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,13 @@
    - add a CLOSURE export mode in volBoundary2obj. Default mode has been changed to "BDRY"
    (David Coeurjolly, [#281](https://github.com/DGtal-team/DGtalTools/pull/281))
 
+- *visualisation*: 
+   - Add SnapShot option for meshViewer and 3dVolViewer 
+     (useful to get visualisation without interaction like for scripting and/or 
+     online demonstration)
+   (Bertrand Kerautret, [#282](https://github.com/DGtal-team/DGtalTools/pull/282))
+
+
 # DGtalTools 0.9.2
 
 - *global*:

--- a/visualisation/3dVolViewer.cpp
+++ b/visualisation/3dVolViewer.cpp
@@ -39,6 +39,7 @@
 #include "DGtal/io/viewers/Viewer3D.h"
 #include "DGtal/io/DrawWithDisplay3DModifier.h"
 #include "DGtal/io/readers/PointListReader.h"
+#include "DGtal/io/readers/MeshReader.h"
 
 #include "DGtal/io/Color.h"
 #include "DGtal/io/colormaps/GradientColorMap.h"
@@ -78,6 +79,10 @@ using namespace Z3i;
                                      Hounsfield scale
   --dicomMax arg (=3000)             set maximum density threshold on 
                                      Hounsfield scale
+  --displayMesh arg                display a Mesh given in OFF or OFS format. 
+  --colorMesh arg                  set the color of Mesh (given from 
+                                   displayMesh option) : r g b a 
+  -d [ --doSnapShotAndExit]  arg,  save display snapshot into file. Notes that the camera setting is set by default according the last saved configuration (use SHIFT+Key_M to save current camera setting in the Viewer3D). If the camera setting was not saved it will use the default camera setting.
   -t [ --transparency ] arg (=255)   transparency
  @endcode
 
@@ -101,6 +106,25 @@ using namespace Z3i;
 
 
 
+
+template < typename Space = DGtal::Z3i::Space, typename KSpace = DGtal::Z3i::KSpace>
+struct ViewerSnap: DGtal::Viewer3D <Space, KSpace>
+{
+
+  ViewerSnap(bool saveSnap): Viewer3D<Space, KSpace>(), mySaveSnap(saveSnap){
+  };
+
+  virtual  void
+  init(){
+    DGtal::Viewer3D<>::init();
+    if(mySaveSnap){
+      QObject::connect(this, SIGNAL(drawFinished(bool)), this, SLOT(saveSnapshot(bool)));
+    }
+  };
+  bool mySaveSnap;
+};
+
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace po = boost::program_options;
 
@@ -114,6 +138,9 @@ int main( int argc, char** argv )
     ("thresholdMin,m",  po::value<int>()->default_value(0), "threshold min to define binary shape" )
     ("thresholdMax,M",  po::value<int>()->default_value(255), "threshold max to define binary shape" )
     ("numMaxVoxel,n",  po::value<int>()->default_value(500000), "set the maximal voxel number to be displayed." )
+    ("displayMesh", po::value<std::string>(), "display a Mesh given in OFF or OFS format. " )
+    ("colorMesh", po::value<std::vector <int> >()->multitoken(), "set the color of Mesh (given from displayMesh option) : r g b a " )
+    ("doSnapShotAndExit,d", po::value<std::string>(), "save display snapshot into file. Notes that the camera setting is set by default according the last saved configuration (use SHIFT+Key_M to save current camera setting in the Viewer3D). If the camera setting was not saved it will use the default camera setting." )
 #ifdef WITH_ITK
     ("dicomMin", po::value<int>()->default_value(-1000), "set minimum density threshold on Hounsfield scale")
     ("dicomMax", po::value<int>()->default_value(3000), "set maximum density threshold on Hounsfield scale")
@@ -157,7 +184,13 @@ int main( int argc, char** argv )
 
 
   QApplication application(argc,argv);
-  Viewer3D<> viewer;
+  typedef ViewerSnap<> Viewer;
+  
+  Viewer viewer(vm.count("doSnapShotAndExit"));
+  if(vm.count("doSnapShotAndExit")){
+    viewer.setSnapshotFileName(QString(vm["doSnapShotAndExit"].as<std::string>().c_str()));
+  }
+
   viewer.setWindowTitle("simple Volume Viewer");
   viewer.show();
 
@@ -217,6 +250,43 @@ int main( int argc, char** argv )
       viewer << vectVoxels.at(i);
     }
   }
+    if(vm.count("displayMesh")){
+    if(vm.count("colorMesh")){
+      std::vector<int> vcol= vm["colorMesh"].as<std::vector<int > >();
+      if(vcol.size()<4){
+        trace.error() << "Not enough parameter: color specification should contains four elements: red, green, blue and alpha values." << std::endl;
+        return 0;
+      }
+      Color c(vcol[0], vcol[1], vcol[2], vcol[3]);
+      viewer.setFillColor(c);
+    }
+
+    DGtal::Mesh<Z3i::RealPoint> aMesh(!vm.count("colorMesh"));
+    MeshReader<Z3i::RealPoint>::importOFFFile(vm["displayMesh"].as<std::string>(), aMesh);
+    viewer << aMesh;
+  }
+
   viewer << Viewer3D<>::updateDisplay;
+  if(vm.count("doSnapShotAndExit")){
+    // Appy cleaning just save the last snap
+    if(!viewer.restoreStateFromFile())
+      {
+        viewer.updateGL();
+      }    
+    std::string name = vm["doSnapShotAndExit"].as<std::string>();
+    std::string extension = name.substr(name.find_last_of(".") + 1);
+    std::string basename = name.substr(0, name.find_last_of("."));
+    for(int i=0; i< viewer.snapshotCounter()-1; i++){
+      std::stringstream s;
+      s << basename << "-"<< setfill('0') << setw(4)<<  i << "." << extension;
+      trace.info() << "erase temp file: " << s.str() << std::endl;
+      remove(s.str().c_str());
+    }
+    std::stringstream s;
+    s << basename << "-"<< setfill('0') << setw(4)<<  viewer.snapshotCounter()-1 << "." << extension;
+    rename(s.str().c_str(), name.c_str());
+    return 0;
+  }
+
   return application.exec();
 }

--- a/visualisation/3dVolViewer.cpp
+++ b/visualisation/3dVolViewer.cpp
@@ -82,7 +82,7 @@ using namespace Z3i;
   --displayMesh arg                display a Mesh given in OFF or OFS format. 
   --colorMesh arg                  set the color of Mesh (given from 
                                    displayMesh option) : r g b a 
-  -d [ --doSnapShotAndExit]  arg,  save display snapshot into file. Notes that the camera setting is set by default according the last saved configuration (use SHIFT+Key_M to save current camera setting in the Viewer3D). If the camera setting was not saved it will use the default camera setting.
+  -d [ --doSnapShotAndExit]  filename,  save display snapshot into file. Notes that the camera setting is set by default according the last saved configuration (use SHIFT+Key_M to save current camera setting in the Viewer3D). If the camera setting was not saved it will use the default camera setting.
   -t [ --transparency ] arg (=255)   transparency
  @endcode
 


### PR DESCRIPTION
# PR Description
Add SnapShot option for meshViewer and 3dVolViewer  (useful to get visualisation without interaction like for scripting and/or online demonstration)

# Checklist

- [x] Doxygen documentation of the code completed (classes, methods, types, members...).
- [x] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [x] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).