### PR TITLE
Display contour add

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,8 @@
      online demonstration). It also contains a new option to display a mesh in
      3DvolViewer.
      (Bertrand Kerautret, [#282](https://github.com/DGtal-team/DGtalTools/pull/282))
+   - Add an option to display vector fields in displayContours
+     (Bertrand Kerautret, [#290](https://github.com/DGtal-team/DGtalTools/pull/290))
 
 - *estimators*:
     - 2dlocalEstimators: add an option to export the generated contour.

--- a/visualisation/displayContours.cpp
+++ b/visualisation/displayContours.cpp
@@ -113,7 +113,7 @@ using namespace DGtal;
   -v [ --displayVectorField ] arg    Add the display of a vector field 
                                      represented by two floating coordinates. 
                                      Each vector is displayed starting from the
-                                     corresponding countour point coordinates.
+                                     corresponding contour point coordinates.
   -v [ --scaleVectorField ] arg (=1) set the scale of the vector field (default
                                      1) (used with --displayVectorField).
   --vectorFieldIndex arg             specify the vector field index (by default
@@ -186,7 +186,7 @@ int main( int argc, char** argv )
     ("noXFIGHeader", " to exclude xfig header in the resulting output stream (no effect with option -outputFile).")
     ("withProcessing", po::value<std::string>(), "Processing (used only when the input is a Freeman chain (--input)):\n\t DSS segmentation {DSS}\n\t  Maximal segments {MS}\n\t Faithful Polygon {FP}\n\t Minimum Length Polygon {MLP}")   
     ("outputFile,o", po::value<std::string>(), " <filename> save output file automatically according the file format extension.")
-    ("displayVectorField,v", po::value<std::string>(), "Add the display of a vector field represented by two floating coordinates. Each vector is displayed starting from the corresponding countour point coordinates.")
+    ("displayVectorField,v", po::value<std::string>(), "Add the display of a vector field represented by two floating coordinates. Each vector is displayed starting from the corresponding contour point coordinates.")
     ("scaleVectorField,v", po::value<double>()->default_value(1.0), "set the scale of the vector field (default 1) (used with --displayVectorField).")
     ("vectorFieldIndex", po::value<std::vector <unsigned int> >()->multitoken(), "specify the vector field index (by default 0,1) (used with --displayVectorField)." )
     ("rotateVectorField", "apply a CCW rotation of 90° (used with --displayVectorField).  ") 

--- a/visualisation/displayContours.cpp
+++ b/visualisation/displayContours.cpp
@@ -110,6 +110,17 @@ using namespace DGtal;
                            Minimum Length Polygon {MLP}
   -o [ --outputFile ] arg  <filename> save output file automatically according 
                           the file format extension.
+  -v [ --displayVectorField ] arg    Add the display of a vector field 
+                                     represented by two floating coordinates. 
+                                     Each vector is displayed starting from the
+                                     corresponding countour point coordinates.
+  -v [ --scaleVectorField ] arg (=1) set the scale of the vector field (default
+                                     1) (used with --displayVectorField).
+  --vectorFieldIndex arg             specify the vector field index (by default
+                                     0,1) (used with --displayVectorField).
+  --rotateVectorField                apply a CCW rotation of 90° (used with 
+                                     --displayVectorField).  
+
   --outputStreamEPS        specify eps for output stream format.
   --outputStreamSVG        specify svg for output stream format.
   --outputStreamFIG        specify fig for output stream format.


### PR DESCRIPTION
# PR Description
Add an option to display vector fields in displayContours.

# Checklist

- [ ] Doxygen documentation of the code completed (classes, methods, types, members...).
- [ ] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [ ] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [ ] Update the readme with potentially a screenshot of the tools if it applies. 
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).