### PR TITLE
Long vol in readers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,12 @@
+# DGtalTools 0.9.4
+
+- *visualisation*:
+  - Improve visualisation tools (3dImageViewer, sliceViewer, 3dVolViewer, vol2sdp)
+    allowing to read longvol including rescaling.
+    (Bertrand Kerautret, [#296](https://github.com/DGtal-team/DGtalTools/pull/296))
+
+
+
 # DGtalTools 0.9.3
 
 - *global*:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 # DGtalTools 0.9.4
 
 - *visualisation*:
-  - Improve visualisation tools (3dImageViewer, sliceViewer, 3dVolViewer, vol2sdp)
+  - Improve visualisation tools (vol2heightfield, vol2obj, vol2raw, vol2sdp, vol2slice, volBoundary2obj, 3dImageViewer, 3dVolViewer, sliceViewer, Viewer3DImage)
     allowing to read longvol including rescaling.
     (Bertrand Kerautret, [#296](https://github.com/DGtal-team/DGtalTools/pull/296))
 

--- a/converters/vol2obj.cpp
+++ b/converters/vol2obj.cpp
@@ -55,12 +55,19 @@ using namespace Z3i;
 
 @code
    -h [ --help ]                    display this message
-   -i [ --input ] arg               vol file (.vol) , pgm3d (.p3d or .pgm3d, pgm
-                                    (with 3 dims)) file or sdp (sequence of
-                                    discrete points)
+   -i [ --input ] arg               vol file (.vol, .longvol .p3d, .pgm3d and if
+                                    WITH_ITK is selected: dicom, dcm, mha, mhd) 
+                                    or sdp (sequence of discrete points).
    -o [ --output ] arg              Output OBJ filename
    -m [ --thresholdMin ] arg (=0)   threshold min to define binary shape
    -M [ --thresholdMax ] arg (=255) threshold max to define binary shape
+
+   --rescaleInputMin arg (=0)       min value used to rescale the input 
+                                    intensity (to avoid basic cast into 8  bits 
+                                    image).
+   --rescaleInputMax arg (=255)     max value used to rescale the input 
+                                    intensity (to avoid basic cast into 8 bits 
+                                    image).
 @endcode
 
 @see
@@ -76,10 +83,12 @@ int main( int argc, char** argv )
   po::options_description general_opt("Allowed options are: ");
   general_opt.add_options()
     ("help,h", "display this message")
-    ("input,i", po::value<std::string>(), "vol file (.vol) , pgm3d (.p3d or .pgm3d, pgm (with 3 dims)) file or sdp (sequence of discrete points)" )
+    ("input,i", po::value<std::string>(), "vol file (.vol, .longvol .p3d, .pgm3d and if WITH_ITK is selected: dicom, dcm, mha, mhd) or sdp (sequence of discrete points).")
     ("output,o", po::value<std::string>(), "Output OBJ filename" )
     ("thresholdMin,m",  po::value<int>()->default_value(0), "threshold min to define binary shape" )
-    ("thresholdMax,M",  po::value<int>()->default_value(255), "threshold max to define binary shape" );
+    ("thresholdMax,M",  po::value<int>()->default_value(255), "threshold max to define binary shape" )
+    ("rescaleInputMin", po::value<DGtal::int64_t>()->default_value(0), "min value used to rescale the input intensity (to avoid basic cast into 8  bits image).")
+    ("rescaleInputMax", po::value<DGtal::int64_t>()->default_value(255), "max value used to rescale the input intensity (to avoid basic cast into 8 bits image).");
 
   bool parseOK=true;
   po::variables_map vm;
@@ -120,16 +129,16 @@ int main( int argc, char** argv )
 
   typedef ImageSelector<Domain, unsigned char>::Type Image;
   string extension = inputFilename.substr(inputFilename.find_last_of(".") + 1);
-  if(extension!="vol" && extension != "p3d" && extension != "pgm3D" &&
-     extension != "pgm3d" && extension != "sdp" && extension != "pgm")
-    {
-      trace.info() << "File extension not recognized: "<< extension << std::endl;
-      return 0;
-    }
 
-  if(extension=="vol" || extension=="pgm3d" || extension=="pgm3D")
+  if(extension!="sdp")
     {
-      Image image = GenericReader<Image>::import (inputFilename );
+      DGtal::int64_t rescaleInputMin = vm["rescaleInputMin"].as<DGtal::int64_t>();
+      DGtal::int64_t rescaleInputMax = vm["rescaleInputMax"].as<DGtal::int64_t>();
+      
+      typedef DGtal::functors::Rescaling<DGtal::int64_t ,unsigned char > RescalFCT;
+      Image image =  GenericReader< Image >::importWithValueFunctor( inputFilename,RescalFCT(rescaleInputMin,
+                                                                                             rescaleInputMax,
+                                                                                             0, 255) );
       trace.info() << "Image loaded: "<<image<< std::endl;
       Domain domain = image.domain();
       for(Domain::ConstIterator it = domain.begin(), itend=domain.end(); it!=itend; ++it){

--- a/converters/vol2sdp.cpp
+++ b/converters/vol2sdp.cpp
@@ -57,11 +57,11 @@ namespace po = boost::program_options;
    @code
    -h [ --help ]                    display this message
    -i [ --input ] arg               vol file (.vol, .longvol .p3d, .pgm3d and if
-   WITH_ITK is selected: dicom, dcm, mha, mhd) 
-   or sdp (sequence of discrete points). For 
-   longvol, dicom, dcm, mha or mhd formats, the
-   input values are linearly scaled between 0 
-   and 255.
+                                    WITH_ITK is selected: dicom, dcm, mha, mhd) 
+                                    or sdp (sequence of discrete points). For 
+                                    longvol, dicom, dcm, mha or mhd formats, the
+                                    input values are linearly scaled between 0 
+                                    and 255.
    -o [ --output ] arg              sequence of discrete point file (.sdp) 
    -e [ --exportImageValues ]       option to export also the image value of the
    voxel in a fourth field.

--- a/converters/vol2sdp.cpp
+++ b/converters/vol2sdp.cpp
@@ -32,7 +32,7 @@
 #include "DGtal/base/Common.h"
 #include "DGtal/helpers/StdDefs.h"
 #include "DGtal/images/ImageContainerBySTLVector.h"
-#include "DGtal/io/readers/VolReader.h"
+#include "DGtal/io/readers/GenericReader.h"
 
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/parsers.hpp>
@@ -47,35 +47,48 @@ namespace po = boost::program_options;
 
 
 /**
- @page vol2sdp vol2sdp
- @brief  Extracts digital points from 3d vol files.
+   @page vol2sdp vol2sdp
+   @brief  Extracts digital points from 3d vol files.
 
-@b Usage: vol2sdp [input] [output]
+   @b Usage: vol2sdp [input] [output]
 
-@b Allowed @b options @b are:
+   @b Allowed @b options @b are:
 
-@code
-  -h [ --help ]                    display this message
-  -i [ --input ] arg               volumetric file (.vol) 
-  -o [ --output ] arg              sequence of discrete point file (.sdp) 
-  -e [ --exportImageValues ]       option to export also the image value of the
-                                   voxel in a fourth field.
-  -m [ --thresholdMin ] arg (=128) min threshold (default 128)
-  -M [ --thresholdMax ] arg (=255) max threshold (default 255)
-@endcode
+   @code
+   -h [ --help ]                    display this message
+   -i [ --input ] arg               vol file (.vol, .longvol .p3d, .pgm3d and if
+   WITH_ITK is selected: dicom, dcm, mha, mhd) 
+   or sdp (sequence of discrete points). For 
+   longvol, dicom, dcm, mha or mhd formats, the
+   input values are linearly scaled between 0 
+   and 255.
+   -o [ --output ] arg              sequence of discrete point file (.sdp) 
+   -e [ --exportImageValues ]       option to export also the image value of the
+   voxel in a fourth field.
+   -m [ --thresholdMin ] arg (=128) min threshold (default 128)
+   -M [ --thresholdMax ] arg (=255) max threshold (default 255)
+   --rescaleInputMin arg (=0)       min value used to rescale the input 
+   intensity (to avoid basic cast into 8  bits 
+   image).
+   --rescaleInputMax arg (=255)     max value used to rescale the input 
+   intensity (to avoid basic cast into 8 bits 
+   image).
 
-@b Example:
-@code 
+
+   @endcode
+
+   @b Example:
+   @code 
    $ vol2sdp -i ${DGtal}/examples/samples/lobster.vol -o volumeList.sdp -m 70
    # Visualisation:
    $ 3dSDPViewer -i volumeList.sdp
-@endcode
+   @endcode
 
-You should obtain such a visualization:
-@image html resVol2sdp.png "resulting visualisation."
+   You should obtain such a visualization:
+   @image html resVol2sdp.png "resulting visualisation."
 
-@see
-@ref vol2sdp.cpp
+   @see
+   @ref vol2sdp.cpp
 
 */
 
@@ -87,11 +100,13 @@ int main( int argc, char** argv )
   po::options_description general_opt("Allowed options are: ");
   general_opt.add_options()
     ("help,h", "display this message")
-    ("input,i", po::value<std::string>(), "volumetric file (.vol) " )
+    ("input,i", po::value<std::string>(), "vol file (.vol, .longvol .p3d, .pgm3d and if WITH_ITK is selected: dicom, dcm, mha, mhd) or sdp (sequence of discrete points). For longvol, dicom, dcm, mha or mhd formats, the input values are linearly scaled between 0 and 255." )
     ("output,o", po::value<std::string>(), "sequence of discrete point file (.sdp) " )
     ("exportImageValues,e","option to export also the image value of the voxel in a fourth field.")
     ("thresholdMin,m", po::value<int>()->default_value(128), "min threshold (default 128)" )
-    ("thresholdMax,M", po::value<int>()->default_value(255), "max threshold (default 255)" );
+    ("thresholdMax,M", po::value<int>()->default_value(255), "max threshold (default 255)" )
+    ("rescaleInputMin", po::value<DGtal::int64_t>()->default_value(0), "min value used to rescale the input intensity (to avoid basic cast into 8  bits image).")
+    ("rescaleInputMax", po::value<DGtal::int64_t>()->default_value(255), "max value used to rescale the input intensity (to avoid basic cast into 8 bits image).");
   
   
   bool parseOK=true;
@@ -124,7 +139,13 @@ int main( int argc, char** argv )
   string outputFilename = vm["output"].as<std::string>();
   
   trace.info() << "Reading input file " << inputFilename ; 
-  Image3D inputImage = DGtal::VolReader<Image3D>::importVol(inputFilename);
+  DGtal::int64_t rescaleInputMin = vm["rescaleInputMin"].as<DGtal::int64_t>();
+  DGtal::int64_t rescaleInputMax = vm["rescaleInputMax"].as<DGtal::int64_t>();
+
+  typedef DGtal::functors::Rescaling<DGtal::int64_t ,unsigned char > RescalFCT;
+  Image3D inputImage =  GenericReader< Image3D >::importWithValueFunctor( inputFilename,RescalFCT(rescaleInputMin,
+                                                                                                  rescaleInputMax,
+                                                                                                  0, 255) );
   trace.info() << " [done] " << std::endl ; 
   std::ofstream outStream;
   outStream.open(outputFilename.c_str());
@@ -151,7 +172,7 @@ int main( int argc, char** argv )
       outStream << std::endl;
     }
   }
- outStream.close();
+  outStream.close();
 
   trace.info() << " [done] " << std::endl ;   
 

--- a/converters/volBoundary2obj.cpp
+++ b/converters/volBoundary2obj.cpp
@@ -14,7 +14,7 @@
  *
  **/
 /**
- * @file 3dVolBoundaryViewer.cpp
+ * @file volBoundary2obj.cpp
  * @ingroup Tools
  * @author Jacques-Olivier Lachaud (\c jacques-olivier.lachaud@univ-savoie.fr )
  * Laboratory of Mathematics (CNRS, UMR 5127), University of Savoie, France
@@ -61,44 +61,49 @@ using namespace DGtal;
 namespace po = boost::program_options;
 
 /**
- @page volBoundary2obj volBoundary2obj
- @brief  Extracts digital points from 3d vol files.
+   @page volBoundary2obj volBoundary2obj
+   @brief  Extracts digital points from 3d vol files.
 
-@b Usage: volBoundary2obj [input] [output]
+   @b Usage: volBoundary2obj [input] [output]
 
-@b Allowed @b options @b are:
+   @b Allowed @b options @b are:
 
-@code
-  -h [ --help ]                    display this message
-  -i [ --input ] arg               vol file (.vol) , pgm3d (.p3d or .pgm3d, pgm
-                                   (with 3 dims)) file or sdp (sequence of 
-                                   discrete points)
-  -o [ --output ] arg              output obj file (.obj)
-  -m [ --thresholdMin ] arg (=0)   threshold min (excluded) to define binary 
-                                   shape
-  -M [ --thresholdMax ] arg (=255) threshold max (included) to define binary 
-                                   shape
-  --dicomMin arg (=-1000)          set minimum density threshold on Hounsfield 
-                                   scale
-  --dicomMax arg (=3000)           set maximum density threshold on Hounsfield 
-                                   scale
-  --mode arg (=BDRY)               set mode for display: INNER: inner voxels,
-                                   OUTER: outer voxels, BDRY: surfels, CLOSURE:
-                                   surfels with linels and pointels.
-  -n [ --normalization ]           Normalization so that the geometry fits in 
-                                   [-1/2,1/2]^3
-@endcode
+   @code
+   -h [ --help ]                    display this message
+   -i [ --input ] arg               vol file (.vol, .longvol .p3d, .pgm3d and if
+                                    WITH_ITK is selected: dicom, dcm, mha, mhd).
+                                    For longvol, dicom, dcm, mha or mhd formats,
+                                    the input values are linearly scaled between
+                                    0 and 255.
+   -o [ --output ] arg              output obj file (.obj)
+   -m [ --thresholdMin ] arg (=0)   threshold min (excluded) to define binary 
+   shape
+   -M [ --thresholdMax ] arg (=255) threshold max (included) to define binary 
+   shape
+   --rescaleInputMin arg (=0)       min value used to rescale the input 
+                                    intensity (to avoid basic cast into 8  bits 
+                                    image).
+   --rescaleInputMax arg (=255)     max value used to rescale the input 
+                                    intensity (to avoid basic cast into 8 bits 
+                                    image).
 
-@b Example:
-@code 
+   --mode arg (=BDRY)               set mode for display: INNER: inner voxels,
+   OUTER: outer voxels, BDRY: surfels, CLOSURE:
+   surfels with linels and pointels.
+   -n [ --normalization ]           Normalization so that the geometry fits in 
+   [-1/2,1/2]^3
+   @endcode
+
+   @b Example:
+   @code 
    $ volBoundary2obj -i $DGtal/examples/samples/lobster.vol -m 80 -o out.obj
-@endcode
+   @endcode
 
-You should obtain such a visualization:
-@image html resVolBoundary2obj.png "resulting visualisation."
+   You should obtain such a visualization:
+   @image html resVolBoundary2obj.png "resulting visualisation."
 
-@see
-@ref volBoundary2obj.cpp
+   @see
+   @ref volBoundary2obj.cpp
 
 */
 
@@ -115,16 +120,14 @@ int main( int argc, char** argv )
   po::options_description general_opt("Allowed options are: ");
   general_opt.add_options()
     ("help,h", "display this message")
-    ("input,i", po::value<std::string>(), "vol file (.vol) , pgm3d (.p3d or .pgm3d, pgm (with 3 dims)) file or sdp (sequence of discrete points)" )
+    ("input,i", po::value<std::string>(), "vol file (.vol, .longvol .p3d, .pgm3d and if WITH_ITK is selected: dicom, dcm, mha, mhd). For longvol, dicom, dcm, mha or mhd formats, the input values are linearly scaled between 0 and 255." )
     ("output,o", po::value<std::string>(), "output obj file (.obj)" )
     ("thresholdMin,m",  po::value<int>()->default_value(0), "threshold min (excluded) to define binary shape" )
     ("thresholdMax,M",  po::value<int>()->default_value(255), "threshold max (included) to define binary shape" )
-#ifdef WITH_ITK
-    ("dicomMin", po::value<int>()->default_value(-1000), "set minimum density threshold on Hounsfield scale")
-    ("dicomMax", po::value<int>()->default_value(3000), "set maximum density threshold on Hounsfield scale")
-#endif
+    ("rescaleInputMin", po::value<DGtal::int64_t>()->default_value(0), "min value used to rescale the input intensity (to avoid basic cast into 8  bits image).")
+    ("rescaleInputMax", po::value<DGtal::int64_t>()->default_value(255), "max value used to rescale the input intensity (to avoid basic cast into 8 bits image).")
     ("mode",  po::value<std::string>()->default_value("BDRY"), "set mode for display: INNER: inner voxels, OUTER: outer voxels, BDRY: surfels (default), CLOSURE: surfels with linels and pointels.")
-   ("normalization,n", "Normalization so that the geometry fits in [-1/2,1/2]^3") ;
+    ("normalization,n", "Normalization so that the geometry fits in [-1/2,1/2]^3") ;
 
   bool parseOK=true;
   po::variables_map vm;
@@ -163,109 +166,88 @@ int main( int argc, char** argv )
   if  (vm.count("normalization"))
     normalization = true;
   
-  string extension = inputFilename.substr(inputFilename.find_last_of(".") + 1);
-  if(extension!="vol" && extension != "p3d" && extension != "pgm3D" && extension != "pgm3d" && extension != "sdp" && extension != "pgm"
-#ifdef WITH_ITK
-     && extension !="dcm"
-#endif
-     ){
-    trace.info() << "File extension not recognized: "<< extension << std::endl;
-    return 0;
-  }
+  DGtal::int64_t rescaleInputMin = vm["rescaleInputMin"].as<DGtal::int64_t>();
+  DGtal::int64_t rescaleInputMax = vm["rescaleInputMax"].as<DGtal::int64_t>();
+  
+  typedef DGtal::functors::Rescaling<DGtal::int64_t ,unsigned char > RescalFCT;
+  Image image =  GenericReader< Image >::importWithValueFunctor( inputFilename,RescalFCT(rescaleInputMin,
+                                                                                         rescaleInputMax,
+                                                                                         0, 255) );  
+  trace.info() << "Image loaded: "<<image<< std::endl;
+  trace.endBlock();
 
-  if(extension=="vol" || extension=="pgm3d" || extension=="pgm3D"
-#ifdef WITH_ITK
-     || extension =="dcm"
-#endif
-     ){
-    trace.beginBlock( "Loading image into memory." );
-#ifdef WITH_ITK
-    int dicomMin = vm["dicomMin"].as<int>();
-    int dicomMax = vm["dicomMax"].as<int>();
-    typedef DGtal::functors::Rescaling<int ,unsigned char > RescalFCT;
-    Image image = extension == "dcm" ? DicomReader< Image,  RescalFCT  >::importDicom( inputFilename,
-										       RescalFCT(dicomMin,
-												 dicomMax,
-												 0, 255) ) :
-      GenericReader<Image>::import( inputFilename );
-#else
-    Image image = GenericReader<Image>::import (inputFilename );
-#endif
-    trace.info() << "Image loaded: "<<image<< std::endl;
-    trace.endBlock();
-
-    trace.beginBlock( "Construct the Khalimsky space from the image domain." );
-    Domain domain = image.domain();
-    KSpace ks;
-    bool space_ok = ks.init( domain.lowerBound(), domain.upperBound(), true );
-    if (!space_ok)
-      {
-	trace.error() << "Error in the Khamisky space construction."<<std::endl;
-	return 2;
-      }
-    trace.endBlock();
-
-    trace.beginBlock( "Wrapping a digital set around image. " );
-    typedef functors::IntervalForegroundPredicate<Image> ThresholdedImage;
-    ThresholdedImage thresholdedImage( image, thresholdMin, thresholdMax );
-    trace.endBlock();
-
-    trace.beginBlock( "Extracting boundary by scanning the space. " );
-    typedef KSpace::SurfelSet SurfelSet;
-    typedef SetOfSurfels< KSpace, SurfelSet > MySetOfSurfels;
-    typedef DigitalSurface< MySetOfSurfels > MyDigitalSurface;
-    MySurfelAdjacency surfAdj( true ); // interior in all directions.
-    MySetOfSurfels theSetOfSurfels( ks, surfAdj );
-    Surfaces<KSpace>::sMakeBoundary( theSetOfSurfels.surfelSet(),
-				     ks, thresholdedImage,
-				     domain.lowerBound(),
-				     domain.upperBound() );
-    MyDigitalSurface digSurf( theSetOfSurfels );
-    trace.info() << "Digital surface has " << digSurf.size() << " surfels."
-		 << std::endl;
-    trace.endBlock();
-
-    trace.beginBlock( "Exporting everything." );
-    Board3D<Space,KSpace> board(ks);
-
-    board << SetMode3D(  ks.unsigns( *digSurf.begin() ).className(), "Basic" );
-
-    typedef MyDigitalSurface::ConstIterator ConstIterator;
-    if ( mode == "BDRY" )
-      for ( ConstIterator it = digSurf.begin(), itE = digSurf.end(); it != itE; ++it )
-        board << ks.unsigns( *it );
-    else if ( mode == "INNER" )
-      for ( ConstIterator it = digSurf.begin(), itE = digSurf.end(); it != itE; ++it )
-        board << ks.sCoords( ks.sDirectIncident( *it, ks.sOrthDir( *it ) ) );
-    else if ( mode == "OUTER" )
-      for ( ConstIterator it = digSurf.begin(), itE = digSurf.end(); it != itE; ++it )
-        board << ks.sCoords( ks.sIndirectIncident( *it, ks.sOrthDir( *it ) ) );
-    else  if (mode == "CLOSURE")
+  trace.beginBlock( "Construct the Khalimsky space from the image domain." );
+  Domain domain = image.domain();
+  KSpace ks;
+  bool space_ok = ks.init( domain.lowerBound(), domain.upperBound(), true );
+  if (!space_ok)
     {
-        std::set<KSpace::Cell> container;
-        for ( ConstIterator it = digSurf.begin(), itE = digSurf.end(); it != itE; ++it )
+      trace.error() << "Error in the Khamisky space construction."<<std::endl;
+      return 2;
+    }
+  trace.endBlock();
+
+  trace.beginBlock( "Wrapping a digital set around image. " );
+  typedef functors::IntervalForegroundPredicate<Image> ThresholdedImage;
+  ThresholdedImage thresholdedImage( image, thresholdMin, thresholdMax );
+  trace.endBlock();
+
+  trace.beginBlock( "Extracting boundary by scanning the space. " );
+  typedef KSpace::SurfelSet SurfelSet;
+  typedef SetOfSurfels< KSpace, SurfelSet > MySetOfSurfels;
+  typedef DigitalSurface< MySetOfSurfels > MyDigitalSurface;
+  MySurfelAdjacency surfAdj( true ); // interior in all directions.
+  MySetOfSurfels theSetOfSurfels( ks, surfAdj );
+  Surfaces<KSpace>::sMakeBoundary( theSetOfSurfels.surfelSet(),
+                                   ks, thresholdedImage,
+                                   domain.lowerBound(),
+                                   domain.upperBound() );
+  MyDigitalSurface digSurf( theSetOfSurfels );
+  trace.info() << "Digital surface has " << digSurf.size() << " surfels."
+               << std::endl;
+  trace.endBlock();
+
+  trace.beginBlock( "Exporting everything." );
+  Board3D<Space,KSpace> board(ks);
+
+  board << SetMode3D(  ks.unsigns( *digSurf.begin() ).className(), "Basic" );
+
+  typedef MyDigitalSurface::ConstIterator ConstIterator;
+  if ( mode == "BDRY" )
+    for ( ConstIterator it = digSurf.begin(), itE = digSurf.end(); it != itE; ++it )
+      board << ks.unsigns( *it );
+  else if ( mode == "INNER" )
+    for ( ConstIterator it = digSurf.begin(), itE = digSurf.end(); it != itE; ++it )
+      board << ks.sCoords( ks.sDirectIncident( *it, ks.sOrthDir( *it ) ) );
+  else if ( mode == "OUTER" )
+    for ( ConstIterator it = digSurf.begin(), itE = digSurf.end(); it != itE; ++it )
+      board << ks.sCoords( ks.sIndirectIncident( *it, ks.sOrthDir( *it ) ) );
+  else  if (mode == "CLOSURE")
+    {
+      std::set<KSpace::Cell> container;
+      for ( ConstIterator it = digSurf.begin(), itE = digSurf.end(); it != itE; ++it )
         {
           container.insert( ks.unsigns( *it ) );
           KSpace::SCells oneNeig = ks.sLowerIncident(*it);
           //Processing linels
           for(KSpace::SCells::ConstIterator itt = oneNeig.begin(), ittend = oneNeig.end(); itt != ittend; ++itt)
-          {
-            container.insert( ks.unsigns( *itt) );
-            KSpace::SCells oneNeig2 = ks.sLowerIncident(*itt);
-            //Processing pointels
-            for(KSpace::SCells::ConstIterator ittt = oneNeig2.begin(), itttend = oneNeig2.end(); ittt != itttend; ++ittt)
-              container.insert( ks.unsigns(*ittt) );
-          }
+            {
+              container.insert( ks.unsigns( *itt) );
+              KSpace::SCells oneNeig2 = ks.sLowerIncident(*itt);
+              //Processing pointels
+              for(KSpace::SCells::ConstIterator ittt = oneNeig2.begin(), itttend = oneNeig2.end(); ittt != itttend; ++ittt)
+                container.insert( ks.unsigns(*ittt) );
+            }
         }
       trace.info()<< "Exporting "<< container.size() << " cells"<<std::endl;
       for(auto cell: container)
         board << cell;
     }
     
-    string outputFilename = vm["output"].as<std::string>();
+  string outputFilename = vm["output"].as<std::string>();
 
-    board.saveOBJ(outputFilename, normalization);
-    trace.endBlock();
-  }
+  board.saveOBJ(outputFilename, normalization);
+  trace.endBlock();
+
   return 0;
 }

--- a/visualisation/3dImageViewer.cpp
+++ b/visualisation/3dImageViewer.cpp
@@ -64,67 +64,67 @@ using namespace Z3i;
 
 
 /**
- @page Doc3dImageViewer 3dImageViewer
+   @page Doc3dImageViewer 3dImageViewer
  
- @brief Displays volume file as a voxel set by using QGLviewer.
+   @brief Displays volume file as a voxel set by using QGLviewer.
 
- @b Usage:  3dImageViewer [options] input
+   @b Usage:  3dImageViewer [options] input
 
- @b Allowed @b options @b are :
+   @b Allowed @b options @b are :
  
- @code
-  -h [ --help ]                    display this message
-  -i [ --input ] arg               vol file (.vol) , pgm3d (.p3d or .pgm3d) 
-                                   file or sdp (sequence of discrete points)
-  --grid                           draw slice images using grid mode. 
-  --intergrid                      draw slice images using inter grid mode. 
-  --emptyMode                      remove the default boundingbox display 
-  --thresholdImage                 threshold the image to define binary shape
-  -m [ --thresholdMin ] arg (=0)   threshold min to define binary shape
-  -M [ --thresholdMax ] arg (=255) threshold max to define binary shape
-  -s [ --displaySDP ] arg          display a set of discrete points (.sdp)
-  --SDPindex arg                   specify the sdp index (by default 0,1,2).
-  --SDPball arg (=0.5)             use balls to display a set of discrete 
-                                   points (used with displaySDP option)
-  --displayMesh arg                display a Mesh given in OFF or OFS format. 
-  --displayDigitalSurface          display the digital surface instead of 
-                                   display all the set of voxels (used with 
-                                   thresholdImage or displaySDP options)
-  --colorizeCC                     colorize each Connected Components of the 
-                                   surface displayed by displayDigitalSurface 
-                                   option.
-  -c [ --colorSDP ] arg            set the color  discrete points: r g b a 
-  --colorMesh arg                  set the color of Mesh (given from 
-                                   displayMesh option) : r g b a 
-  -x [ --scaleX ] arg (=1)         set the scale value in the X direction 
-                                   (default 1.0)
-  -y [ --scaleY ] arg (=1)         set the scale value in the Y direction 
-                                   (default 1.0)
-  -z [ --scaleZ ] arg (=1)         set the scale value in the Z direction 
-                                   (default 1.0)
-  --dicomMin arg (=-1000)          set minimum density threshold on Hounsfield 
-                                   scale
-  --dicomMax arg (=3000)           set maximum density threshold on Hounsfield 
-                                   scale
-  -t [ --transparency ] arg (=255) transparency
- @endcode
+   @code
+   -h [ --help ]                    display this message
+   -i [ --input ] arg               vol file (.vol) , pgm3d (.p3d or .pgm3d) 
+   file or sdp (sequence of discrete points)
+   --grid                           draw slice images using grid mode. 
+   --intergrid                      draw slice images using inter grid mode. 
+   --emptyMode                      remove the default boundingbox display 
+   --thresholdImage                 threshold the image to define binary shape
+   -m [ --thresholdMin ] arg (=0)   threshold min to define binary shape
+   -M [ --thresholdMax ] arg (=255) threshold max to define binary shape
+   -s [ --displaySDP ] arg          display a set of discrete points (.sdp)
+   --SDPindex arg                   specify the sdp index (by default 0,1,2).
+   --SDPball arg (=0.5)             use balls to display a set of discrete 
+   points (used with displaySDP option)
+   --displayMesh arg                display a Mesh given in OFF or OFS format. 
+   --displayDigitalSurface          display the digital surface instead of 
+   display all the set of voxels (used with 
+   thresholdImage or displaySDP options)
+   --colorizeCC                     colorize each Connected Components of the 
+   surface displayed by displayDigitalSurface 
+   option.
+   -c [ --colorSDP ] arg            set the color  discrete points: r g b a 
+   --colorMesh arg                  set the color of Mesh (given from 
+   displayMesh option) : r g b a 
+   -x [ --scaleX ] arg (=1)         set the scale value in the X direction 
+   (default 1.0)
+   -y [ --scaleY ] arg (=1)         set the scale value in the Y direction 
+   (default 1.0)
+   -z [ --scaleZ ] arg (=1)         set the scale value in the Z direction 
+   (default 1.0)
+   --dicomMin arg (=-1000)          set minimum density threshold on Hounsfield 
+   scale
+   --dicomMax arg (=3000)           set maximum density threshold on Hounsfield 
+   scale
+   -t [ --transparency ] arg (=255) transparency
+   @endcode
 
 
- @b Example: 
- With the image display you can also threshold the image and display a set of voxel:  
- @code
-    3dImageViewer -i $DGtal/examples/samples/lobster.vol --thresholdImage -m 180
- @endcode
+   @b Example: 
+   With the image display you can also threshold the image and display a set of voxel:  
+   @code
+   3dImageViewer -i $DGtal/examples/samples/lobster.vol --thresholdImage -m 180
+   @endcode
 
- You should obtain such a result:
+   You should obtain such a result:
 
- @image html res3dImageViewer.png "resulting visualisation of 3d image with thresholded set of voxels."
+   @image html res3dImageViewer.png "resulting visualisation of 3d image with thresholded set of voxels."
  
 
- @see
- @ref 3dImageViewer.cpp
+   @see
+   @ref 3dImageViewer.cpp
 
- */
+*/
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace po = boost::program_options;
@@ -174,8 +174,8 @@ int main( int argc, char** argv )
   if( !parseOK || vm.count("help")||argc<=1)
     {
       std::cout << "Usage: " << argv[0] << " [input]\n"
-    << "Displays volume file as a voxel set by using QGLviewer"
-    << general_opt << "\n";
+                << "Displays volume file as a voxel set by using QGLviewer"
+                << general_opt << "\n";
       return 0;
     }
 
@@ -224,7 +224,7 @@ int main( int argc, char** argv )
 
   trace.info() << "Image loaded: "<<image<< std::endl;
   viewer.setVolImage(&image);
-  viewer << Z3i::Point(512, 512, 0);
+  
   // Used to display 3D surface
   Z3i::DigitalSet set3d(domain);
 
@@ -241,13 +241,13 @@ int main( int argc, char** argv )
       unsigned char  val= image( (*it) );
       Color c= gradient(val);
       if(val<=thresholdMax && val >=thresholdMin){
-  if(!vm.count("displayDigitalSurface")){
+        if(!vm.count("displayDigitalSurface")){
           viewer <<  CustomColors3D(Color((float)(c.red()), (float)(c.green()),(float)(c.blue()), transp),
                                     Color((float)(c.red()), (float)(c.green()),(float)(c.blue()), transp));
           viewer << *it;
-  }
+        }
       }else{
-  set3d.insert(*it);
+        set3d.insert(*it);
       }
     }
   }
@@ -325,22 +325,31 @@ int main( int argc, char** argv )
     viewer << DGtal::SetMode3D(vectConnectedSCell.at(0).at(0).className(), "Basic");
     for(unsigned int i= 0; i <vectConnectedSCell.size(); i++){
       for(unsigned int j= 0; j <vectConnectedSCell.at(i).size(); j++){
-  if(vm.count("colorizeCC")){
-    DGtal::Color c= gradient(i);
-    viewer << CustomColors3D(Color(250, 0,0, transp), Color(c.red(),
-                  c.green(),
-                  c.blue(), transp));
-  }else  if(vm.count("colorSDP")){
-    std::vector<int> vcol= vm["colorSDP"].as<std::vector<int > >();
-    Color c(vcol[0], vcol[1], vcol[2], vcol[3]);
-    viewer << CustomColors3D(c, c);
-  }
+        if(vm.count("colorizeCC")){
+          DGtal::Color c= gradient(i);
+          viewer << CustomColors3D(Color(250, 0,0, transp), Color(c.red(),
+                                                                  c.green(),
+                                                                  c.blue(), transp));
+        }else  if(vm.count("colorSDP")){
+          std::vector<int> vcol= vm["colorSDP"].as<std::vector<int > >();
+          Color c(vcol[0], vcol[1], vcol[2], vcol[3]);
+          viewer << CustomColors3D(c, c);
+        }
 
-  viewer << vectConnectedSCell.at(i).at(j);
+        viewer << vectConnectedSCell.at(i).at(j);
       }
     }
   }
   
   viewer << Viewer3D<>::updateDisplay;
+  DGtal::Z3i::Point size = image.domain().upperBound() - image.domain().lowerBound();
+  DGtal::Z3i::Point center = image.domain().lowerBound()+size/2;
+  unsigned int maxDist = std::max(std::max(size[2], size[1]), size[0]);
+  viewer.camera()->setPosition(qglviewer::Vec(center[0],center[1], 
+                                              center[2] + 2.0*maxDist));
+  viewer.camera()->setSceneCenter(qglviewer::Vec(center[0],center[1],center[2]));
+  
+
+
   return application.exec();
 }

--- a/visualisation/3dImageViewer.cpp
+++ b/visualisation/3dImageViewer.cpp
@@ -74,8 +74,9 @@ using namespace Z3i;
  
    @code
    -h [ --help ]                    display this message
-   -i [ --input ] arg               vol file (.vol) , pgm3d (.p3d or .pgm3d) 
-   file or sdp (sequence of discrete points)
+   -i [ --input ] arg               vol file (.vol, .longvol .p3d, .pgm3d and if
+                                    WITH_ITK is selected: dicom, dcm, mha, mhd) 
+                                    or sdp (sequence of discrete points).
    --grid                           draw slice images using grid mode. 
    --intergrid                      draw slice images using inter grid mode. 
    --emptyMode                      remove the default boundingbox display 
@@ -142,7 +143,7 @@ int main( int argc, char** argv )
   po::options_description general_opt("Allowed options are ");
   general_opt.add_options()
     ("help,h", "display this message")
-    ("input,i", po::value<std::string>(), "vol file (.vol) , pgm3d (.p3d or .pgm3d) file or sdp (sequence of discrete points)" )
+    ("input,i", po::value<std::string>(), "vol file (.vol, .longvol .p3d, .pgm3d and if WITH_ITK is selected: dicom, dcm, mha, mhd) or sdp (sequence of discrete points)" )
     ("grid", "draw slice images using grid mode. " )
     ("intergrid", "draw slice images using inter grid mode. " )
     ("emptyMode", "remove the default boundingbox display " )

--- a/visualisation/3dImageViewer.cpp
+++ b/visualisation/3dImageViewer.cpp
@@ -76,7 +76,9 @@ using namespace Z3i;
    -h [ --help ]                    display this message
    -i [ --input ] arg               vol file (.vol, .longvol .p3d, .pgm3d and if
                                     WITH_ITK is selected: dicom, dcm, mha, mhd) 
-                                    or sdp (sequence of discrete points).
+                                    or sdp (sequence of discrete points). For 
+                                    longvol, dicom, dcm, mha or mhd formats, the 
+                                    input values are scaled into 0 and 255.
    --grid                           draw slice images using grid mode. 
    --intergrid                      draw slice images using inter grid mode. 
    --emptyMode                      remove the default boundingbox display 
@@ -143,7 +145,7 @@ int main( int argc, char** argv )
   po::options_description general_opt("Allowed options are ");
   general_opt.add_options()
     ("help,h", "display this message")
-    ("input,i", po::value<std::string>(), "vol file (.vol, .longvol .p3d, .pgm3d and if WITH_ITK is selected: dicom, dcm, mha, mhd) or sdp (sequence of discrete points)" )
+    ("input,i", po::value<std::string>(), "vol file (.vol, .longvol .p3d, .pgm3d and if WITH_ITK is selected: dicom, dcm, mha, mhd) or sdp (sequence of discrete points). For longvol, dicom, dcm, mha or mhd formats, the input values are scaled into 0 and 255." )
     ("grid", "draw slice images using grid mode. " )
     ("intergrid", "draw slice images using inter grid mode. " )
     ("emptyMode", "remove the default boundingbox display " )

--- a/visualisation/3dImageViewer.cpp
+++ b/visualisation/3dImageViewer.cpp
@@ -197,14 +197,7 @@ int main( int argc, char** argv )
 
   double ballRadius = vm["SDPball"].as<double>();
   string extension = inputFilename.substr(inputFilename.find_last_of(".") + 1);
-  if(extension!="vol" && extension!="longvol" && extension != "p3d" && extension != "pgm3D" && extension != "pgm3d" && extension != "sdp" && extension != "pgm"
-#ifdef WITH_ITK
-     && extension !="dcm"
-#endif
-     ){
-    trace.info() << "File extension not recognized: "<< extension << std::endl;
-    return 0;
-  }
+ 
   Viewer3DImage<>::ModeVisu mode;
   if(vm.count("emptyMode"))
     mode=Viewer3DImage<>::Empty;

--- a/visualisation/3dImageViewer.cpp
+++ b/visualisation/3dImageViewer.cpp
@@ -78,7 +78,7 @@ using namespace Z3i;
                                     WITH_ITK is selected: dicom, dcm, mha, mhd) 
                                     or sdp (sequence of discrete points). For 
                                     longvol, dicom, dcm, mha or mhd formats, the 
-                                    input values are scaled into 0 and 255.
+                                    input values are linearly scaled between 0 and 255.
    --grid                           draw slice images using grid mode. 
    --intergrid                      draw slice images using inter grid mode. 
    --emptyMode                      remove the default boundingbox display 
@@ -145,7 +145,7 @@ int main( int argc, char** argv )
   po::options_description general_opt("Allowed options are ");
   general_opt.add_options()
     ("help,h", "display this message")
-    ("input,i", po::value<std::string>(), "vol file (.vol, .longvol .p3d, .pgm3d and if WITH_ITK is selected: dicom, dcm, mha, mhd) or sdp (sequence of discrete points). For longvol, dicom, dcm, mha or mhd formats, the input values are scaled into 0 and 255." )
+    ("input,i", po::value<std::string>(), "vol file (.vol, .longvol .p3d, .pgm3d and if WITH_ITK is selected: dicom, dcm, mha, mhd) or sdp (sequence of discrete points). For longvol, dicom, dcm, mha or mhd formats, the input values are linearly scaled between 0 and 255." )
     ("grid", "draw slice images using grid mode. " )
     ("intergrid", "draw slice images using inter grid mode. " )
     ("emptyMode", "remove the default boundingbox display " )

--- a/visualisation/3dImageViewer.cpp
+++ b/visualisation/3dImageViewer.cpp
@@ -102,10 +102,12 @@ using namespace Z3i;
    (default 1.0)
    -z [ --scaleZ ] arg (=1)         set the scale value in the Z direction 
    (default 1.0)
-   --dicomMin arg (=-1000)          set minimum density threshold on Hounsfield 
-   scale
-   --dicomMax arg (=3000)           set maximum density threshold on Hounsfield 
-   scale
+  --rescaleInputMin arg (=0)       min value used to rescale the input 
+                                   intensity (to avoid basic cast into 8  bits 
+                                   image).
+  --rescaleInputMax arg (=255)     max value used to rescale the input 
+                                   intensity (to avoid basic cast into 8 bits 
+                                   image).
    -t [ --transparency ] arg (=255) transparency
    @endcode
 

--- a/visualisation/3dVolViewer.cpp
+++ b/visualisation/3dVolViewer.cpp
@@ -14,14 +14,12 @@
  *
  **/
 /**
- * @file visuDistanceTransform.cpp
- * @ingroup Examples
+ * @file 3dVolViewer.cpp
  * @author Bertrand Kerautret (\c kerautre@loria.fr )
- * LORIA (CNRS, UMR 7503), University of Nancy, France
+ * LORIA (CNRS, UMR 7503), University of Lorraine, France
  *
  * @date 2011/01/04
  *
- * An example file named qglViewer.
  *
  * This file is part of the DGtal library.
  */
@@ -33,9 +31,6 @@
 #include "DGtal/base/BasicFunctors.h"
 #include "DGtal/helpers/StdDefs.h"
 #include "DGtal/io/readers/GenericReader.h"
-#ifdef WITH_ITK
-#include "DGtal/io/readers/DicomReader.h"
-#endif
 #include "DGtal/io/viewers/Viewer3D.h"
 #include "DGtal/io/DrawWithDisplay3DModifier.h"
 #include "DGtal/io/readers/PointListReader.h"
@@ -55,54 +50,60 @@ using namespace Z3i;
 
 
 /**
- @page Doc3dVolViewer 3dVolViewer
+   @page Doc3dVolViewer 3dVolViewer
  
- @brief Displays volume file as a voxel set by using QGLviewer.
+   @brief Displays volume file as a voxel set by using QGLviewer.
 
- The mode  specifies if you wish to see surface elements (BDRY), the inner
- voxels (INNER) or the outer voxels (OUTER) that touch the boundary.
+   The mode  specifies if you wish to see surface elements (BDRY), the inner
+   voxels (INNER) or the outer voxels (OUTER) that touch the boundary.
 
- @b Usage:   3dVolViewer [input]
+   @b Usage:   3dVolViewer [input]
 
- @b Allowed @b options @b are :
+   @b Allowed @b options @b are :
  
- @code
-  -h [ --help ]                      display this message
-  -i [ --input ] arg                 vol file (.vol) , pgm3d (.p3d or .pgm3d, 
-                                     pgm (with 3 dims)) file or sdp (sequence 
-                                     of discrete points)
-  -m [ --thresholdMin ] arg (=0)     threshold min to define binary shape
-  -M [ --thresholdMax ] arg (=255)   threshold max to define binary shape
-  -n [ --numMaxVoxel ] arg (=500000) set the maximal voxel number to be 
-                                     displayed.
-  --dicomMin arg (=-1000)            set minimum density threshold on 
-                                     Hounsfield scale
-  --dicomMax arg (=3000)             set maximum density threshold on 
-                                     Hounsfield scale
-  --displayMesh arg                display a Mesh given in OFF or OFS format. 
-  --colorMesh arg                  set the color of Mesh (given from 
-                                   displayMesh option) : r g b a 
-  -d [ --doSnapShotAndExit]  filename,  save display snapshot into file. Notes that the camera setting is set by default according the last saved configuration (use SHIFT+Key_M to save current camera setting in the Viewer3D). If the camera setting was not saved it will use the default camera setting.
-  -t [ --transparency ] arg (=255)   transparency
- @endcode
+   @code
+   -h [ --help ]                      display this message
+   -i [ --input ] arg                sdp (sequence of discrete points)  or vol
+                                     file (.vol, .longvol .p3d, .pgm3d and 
+                                     if WITH_ITK is selected: dicom, dcm, mha, 
+                                     mhd) or sdp (sequence of discrete points).
+                                     For longvol, dicom, dcm, mha or mhd 
+                                     formats, the input values are linearly 
+                                     scaled between 0 and 255.
+   -m [ --thresholdMin ] arg (=0)     threshold min to define binary shape
+   -M [ --thresholdMax ] arg (=255)   threshold max to define binary shape
+   -n [ --numMaxVoxel ] arg (=500000) set the maximal voxel number to be 
+   displayed.
+  --rescaleInputMin arg (=0)         min value used to rescale the input 
+                                     intensity (to avoid basic cast into 8  
+                                     bits image).
+  --rescaleInputMax arg (=255)       max value used to rescale the input 
+                                     intensity (to avoid basic cast into 8 bits
+                                     image).
+   --displayMesh arg                display a Mesh given in OFF or OFS format. 
+   --colorMesh arg                  set the color of Mesh (given from 
+   displayMesh option) : r g b a 
+   -d [ --doSnapShotAndExit]  filename,  save display snapshot into file. Notes that the camera setting is set by default according the last saved configuration (use SHIFT+Key_M to save current camera setting in the Viewer3D). If the camera setting was not saved it will use the default camera setting.
+   -t [ --transparency ] arg (=255)   transparency
+   @endcode
 
 
- @b Example: 
+   @b Example: 
 
 
- @code
- $ 3dVolViewer -i $DGtal/examples/samples/lobster.vol -m 60 -t 10
- @endcode
+   @code
+   $ 3dVolViewer -i $DGtal/examples/samples/lobster.vol -m 60 -t 10
+   @endcode
 
- You should obtain such a result:
+   You should obtain such a result:
 
- @image html res3dVolViewer.png "Resulting visualization."
+   @image html res3dVolViewer.png "Resulting visualization."
  
 
- @see
- @ref 3dVolViewer.cpp
+   @see
+   @ref 3dVolViewer.cpp
 
- */
+*/
 
 
 
@@ -134,17 +135,15 @@ int main( int argc, char** argv )
   po::options_description general_opt("Allowed options are: ");
   general_opt.add_options()
     ("help,h", "display this message")
-    ("input,i", po::value<std::string>(), "vol file (.vol) , pgm3d (.p3d or .pgm3d, pgm (with 3 dims)) file or sdp (sequence of discrete points)" )
+    ("input,i", po::value<std::string>(), "vol file (.vol, .longvol .p3d, .pgm3d and if WITH_ITK is selected: dicom, dcm, mha, mhd) or sdp (sequence of discrete points). For longvol, dicom, dcm, mha or mhd formats, the input values are linearly scaled between 0 and 255." )
     ("thresholdMin,m",  po::value<int>()->default_value(0), "threshold min to define binary shape" )
     ("thresholdMax,M",  po::value<int>()->default_value(255), "threshold max to define binary shape" )
     ("numMaxVoxel,n",  po::value<int>()->default_value(500000), "set the maximal voxel number to be displayed." )
     ("displayMesh", po::value<std::string>(), "display a Mesh given in OFF or OFS format. " )
     ("colorMesh", po::value<std::vector <int> >()->multitoken(), "set the color of Mesh (given from displayMesh option) : r g b a " )
     ("doSnapShotAndExit,d", po::value<std::string>(), "save display snapshot into file. Notes that the camera setting is set by default according the last saved configuration (use SHIFT+Key_M to save current camera setting in the Viewer3D). If the camera setting was not saved it will use the default camera setting." )
-#ifdef WITH_ITK
-    ("dicomMin", po::value<int>()->default_value(-1000), "set minimum density threshold on Hounsfield scale")
-    ("dicomMax", po::value<int>()->default_value(3000), "set maximum density threshold on Hounsfield scale")
-#endif
+    ("rescaleInputMin", po::value<DGtal::int64_t>()->default_value(0), "min value used to rescale the input intensity (to avoid basic cast into 8  bits image).")
+    ("rescaleInputMax", po::value<DGtal::int64_t>()->default_value(255), "max value used to rescale the input intensity (to avoid basic cast into 8 bits image).")
     ("transparency,t",  po::value<uint>()->default_value(255), "transparency") ;
 
   bool parseOK=true;
@@ -196,61 +195,44 @@ int main( int argc, char** argv )
 
   typedef ImageSelector<Domain, unsigned char>::Type Image;
   string extension = inputFilename.substr(inputFilename.find_last_of(".") + 1);
-  if(extension!="vol" && extension != "p3d" && extension != "pgm3D" && extension != "pgm3d" && extension != "sdp" && extension != "pgm"
- #ifdef WITH_ITK
-    && extension !="dcm"
-#endif
-){
-    trace.info() << "File extension not recognized: "<< extension << std::endl;
-    return 0;
-  }
-
-  if(extension=="vol" || extension=="pgm3d" || extension=="pgm3D"
-#ifdef WITH_ITK
-    || extension =="dcm"
-#endif
-){
-    unsigned int numDisplayed=0;
-
-#ifdef WITH_ITK
-   int dicomMin = vm["dicomMin"].as<int>();
-   int dicomMax = vm["dicomMax"].as<int>();
-   typedef DGtal::functors::Rescaling<int ,unsigned char > RescalFCT;
-   Image image = extension == "dcm" ? DicomReader< Image,  RescalFCT  >::importDicom( inputFilename,
-                        RescalFCT(dicomMin,
-                            dicomMax,
-                            0, 255) ) :
-     GenericReader<Image>::import( inputFilename );
-#else
-   Image image = GenericReader<Image>::import (inputFilename );
-#endif
-
-    trace.info() << "Image loaded: "<<image<< std::endl;
-    Domain domain = image.domain();
-    GradientColorMap<long> gradient( thresholdMin, thresholdMax);
-    gradient.addColor(Color::Blue);
-    gradient.addColor(Color::Green);
-    gradient.addColor(Color::Yellow);
-    gradient.addColor(Color::Red);
-    for(Domain::ConstIterator it = domain.begin(), itend=domain.end(); it!=itend; ++it){
-      unsigned char  val= image( (*it) );
-      if(limitDisplay && numDisplayed > numDisplayedMax)
-  break;
-      Color c= gradient(val);
-      if(val<=thresholdMax && val >=thresholdMin){
-  viewer <<  CustomColors3D(Color((float)(c.red()), (float)(c.green()),(float)(c.blue()), transp),
-          Color((float)(c.red()), (float)(c.green()),(float)(c.blue()), transp));
-  viewer << *it;
-  numDisplayed++;
+  if(extension != "sdp")
+    {
+      unsigned int numDisplayed=0;
+      DGtal::int64_t rescaleInputMin = vm["rescaleInputMin"].as<DGtal::int64_t>();
+      DGtal::int64_t rescaleInputMax = vm["rescaleInputMax"].as<DGtal::int64_t>();
+  
+      typedef DGtal::functors::Rescaling<DGtal::int64_t ,unsigned char > RescalFCT;
+      Image image =  GenericReader< Image >::importWithValueFunctor( inputFilename,RescalFCT(rescaleInputMin,
+                                                                                             rescaleInputMax,
+                                                                                             0, 255) );
+  
+  
+      trace.info() << "Image loaded: "<<image<< std::endl;
+      Domain domain = image.domain();
+      GradientColorMap<long> gradient( thresholdMin, thresholdMax);
+      gradient.addColor(Color::Blue);
+      gradient.addColor(Color::Green);
+      gradient.addColor(Color::Yellow);
+      gradient.addColor(Color::Red);
+      for(Domain::ConstIterator it = domain.begin(), itend=domain.end(); it!=itend; ++it){
+        unsigned char  val= image( (*it) );
+        if(limitDisplay && numDisplayed > numDisplayedMax)
+          break;
+        Color c= gradient(val);
+        if(val<=thresholdMax && val >=thresholdMin){
+          viewer <<  CustomColors3D(Color((float)(c.red()), (float)(c.green()),(float)(c.blue()), transp),
+                                    Color((float)(c.red()), (float)(c.green()),(float)(c.blue()), transp));
+          viewer << *it;
+          numDisplayed++;
+        }
       }
-    }
-  }else if(extension=="sdp"){
+    }else if(extension=="sdp"){
     vector<Z3i::RealPoint> vectVoxels = PointListReader<Z3i::RealPoint>::getPointsFromFile(inputFilename);
     for(unsigned int i=0;i< vectVoxels.size(); i++){
       viewer << vectVoxels.at(i);
     }
   }
-    if(vm.count("displayMesh")){
+  if(vm.count("displayMesh")){
     if(vm.count("colorMesh")){
       std::vector<int> vcol= vm["colorMesh"].as<std::vector<int > >();
       if(vcol.size()<4){

--- a/visualisation/sliceViewer.cpp
+++ b/visualisation/sliceViewer.cpp
@@ -71,10 +71,9 @@ namespace po = boost::program_options;
    @code
    -h [ --help ]                     display this message
    -i [ --input ] arg                vol file (.vol, .longvol .p3d, .pgm3d and if 
-                                     WITH_ITK is selected: dicom, dcm, mha, mhd) or 
-                                     sdp (sequence of discrete points). For longvol, 
-                                     dicom, dcm, mha or mhd formats, the input values
-                                     are linearly scaled between 0 and 255.
+                                     WITH_ITK is selected: dicom, dcm, mha, mhd). 
+                                     For longvol, dicom, dcm, mha or mhd formats, the
+                                     input values are linearly scaled between 0 and 255.
    --hueColorMap                     use hue color map to display images.
    --gradHotColorMap                 use hot gradient color map to display images.
    --gradCoolColorMap                use cool gradient color map to display images.
@@ -424,7 +423,7 @@ int main( int argc, char** argv )
   po::options_description general_opt("Allowed options are: ");
   general_opt.add_options()
     ("help,h", "display this message")
-    ("input,i", po::value<std::string>(), "vol file (.vol, .longvol .p3d, .pgm3d and if WITH_ITK is selected: dicom, dcm, mha, mhd) or sdp (sequence of discrete points). For longvol, dicom, dcm, mha or mhd formats, the input values are linearly scaled between 0 and 255." )
+    ("input,i", po::value<std::string>(), "vol file (.vol, .longvol .p3d, .pgm3d and if WITH_ITK is selected: dicom, dcm, mha, mhd). For longvol, dicom, dcm, mha or mhd formats, the input values are linearly scaled between 0 and 255." )
     ("hueColorMap", "use hue color map to display images." )
     ("gradHotColorMap", "use hot gradient color map to display images." )
     ("gradCoolColorMap", "use cool gradient color map to display images." )

--- a/visualisation/sliceViewer.cpp
+++ b/visualisation/sliceViewer.cpp
@@ -63,37 +63,37 @@ namespace po = boost::program_options;
 
 
 /**
- @page sliceViewer sliceViewer
+   @page sliceViewer sliceViewer
  
- @brief  Displays volume file with slice image by using QT and QGLviewer.
+   @brief  Displays volume file with slice image by using QT and QGLviewer.
 
- @b Usage:   sliceViewer [input]
+   @b Usage:   sliceViewer [input]
 
- @b Allowed @b options @b are :
+   @b Allowed @b options @b are :
  
- @code
-  -h [ --help ]           display this message
-  -i [ --input ] arg      vol file (.vol) , pgm3d (.p3d or .pgm3d, pgm (with 3 
-                          dims)) file or sdp (sequence of discrete points)
-  --hueColorMap           use hue color map to display images.
-  --gradHotColorMap       use hot gradient color map to display images.
-  --gradCoolColorMap      use cool gradient color map to display images.
-  --dicomMin arg (=-1000) set minimum density threshold on Hounsfield scale
-  --dicomMax arg (=3000)  set maximum density threshold on Hounsfield scale
- @endcode
+   @code
+   -h [ --help ]           display this message
+   -i [ --input ] arg      vol file (.vol) , pgm3d (.p3d or .pgm3d, pgm (with 3 
+   dims)) file or sdp (sequence of discrete points)
+   --hueColorMap           use hue color map to display images.
+   --gradHotColorMap       use hot gradient color map to display images.
+   --gradCoolColorMap      use cool gradient color map to display images.
+   --dicomMin arg (=-1000) set minimum density threshold on Hounsfield scale
+   --dicomMax arg (=3000)  set maximum density threshold on Hounsfield scale
+   @endcode
 
- @b Example: 
+   @b Example: 
 
- @code
- $ sliceViewer -i  $DGtal/examples/samples/lobster.vol
- @endcode
+   @code
+   $ sliceViewer -i  $DGtal/examples/samples/lobster.vol
+   @endcode
 
- @image html resSliceViewer.png " "
+   @image html resSliceViewer.png " "
 
-@see
- @ref sliceViewer.cpp
+   @see
+   @ref sliceViewer.cpp
 
- */
+*/
 
 
 
@@ -117,7 +117,7 @@ getImage(const TImage &anImage, double gridSize, const MainWindow::ColorMapFunct
   scales.push_back(gridSize);
   scales.push_back(gridSize);  
   functors::BasicDomainSubSampler<typename TImage::Domain,  int, double> subSampler (anImage.domain(),
-                                                                                             scales, Z2i::Point(0,0));
+                                                                                     scales, Z2i::Point(0,0));
   typename TImage::Domain newDomain = subSampler.getSubSampledDomain();
   ConstImageAdapterForSubSampling  scaledImage (anImage, newDomain, subSampler, colFunctor );
   unsigned int height = scaledImage.domain().upperBound()[1]-scaledImage.domain().lowerBound()[1];
@@ -420,16 +420,12 @@ int main( int argc, char** argv )
   po::options_description general_opt("Allowed options are: ");
   general_opt.add_options()
     ("help,h", "display this message")
-    ("input,i", po::value<std::string>(), "vol file (.vol) , pgm3d (.p3d or .pgm3d, pgm (with 3 dims)) file or sdp (sequence of discrete points)" )
+    ("input,i", po::value<std::string>(), "vol file (.vol, .longvol .p3d, .pgm3d and if WITH_ITK is selected: dicom, dcm, mha, mhd) or sdp (sequence of discrete points). For longvol, dicom, dcm, mha or mhd formats, the input values are linearly scaled between 0 and 255." )
     ("hueColorMap", "use hue color map to display images." )
     ("gradHotColorMap", "use hot gradient color map to display images." )
     ("gradCoolColorMap", "use cool gradient color map to display images." )
-
-#ifdef WITH_ITK
-    ("dicomMin", po::value<int>()->default_value(-1000), "set minimum density threshold on Hounsfield scale")
-    ("dicomMax", po::value<int>()->default_value(3000), "set maximum density threshold on Hounsfield scale")
-#endif
-    ;
+    ("rescaleInputMin", po::value<DGtal::int64_t>()->default_value(0), "min value used to rescale the input intensity (to avoid basic cast into 8  bits image).")
+    ("rescaleInputMax", po::value<DGtal::int64_t>()->default_value(255), "max value used to rescale the input intensity (to avoid basic cast into 8 bits image).");
 
   bool parseOK=true;
   po::variables_map vm;
@@ -459,63 +455,42 @@ int main( int argc, char** argv )
   typedef ImageContainerBySTLVector < Z3i::Domain, unsigned char > Image3D;
   typedef ImageContainerBySTLVector < Z2i::Domain, unsigned char > Image2D;
 
-  string extension = inputFilename.substr(inputFilename.find_last_of(".") + 1);
-  if(extension!="vol" && extension != "p3d" && extension != "pgm3D" && extension != "pgm3d" && extension != "sdp" && extension != "pgm"
-#ifdef WITH_ITK
-     && extension !="dcm"
-#endif
-     ){
-    trace.info() << "File extension not recognized: "<< extension << std::endl;
-    return 0;
-  }
+  DGtal::int64_t rescaleInputMin = vm["rescaleInputMin"].as<DGtal::int64_t>();
+  DGtal::int64_t rescaleInputMax = vm["rescaleInputMax"].as<DGtal::int64_t>();
 
-  if(extension=="vol" || extension=="pgm3d" || extension=="pgm3D"
-#ifdef WITH_ITK
-     || extension =="dcm"
-#endif
-     ){
-
-#ifdef WITH_ITK
-    int dicomMin = vm["dicomMin"].as<int>();
-    int dicomMax = vm["dicomMax"].as<int>();
-    typedef functors::Rescaling<int ,unsigned char > RescalFCT;
-    Image3D image = extension == "dcm" ? DicomReader< Image3D,  RescalFCT  >::importDicom( inputFilename,
-                                                                                           RescalFCT(dicomMin,
-                                                                                                     dicomMax,
-                                                                                                     0, 255) ) :
-      GenericReader<Image3D>::import( inputFilename );
-    trace.info() << "Imported ITK..."<< std::endl;
-#else
-    Image3D image = GenericReader<Image3D>::import (inputFilename );
-    trace.info() << "Imported..."<< std::endl;
-#endif
+  typedef DGtal::functors::Rescaling<DGtal::int64_t ,unsigned char > RescalFCT;
+  Image3D image =  GenericReader< Image3D >::importWithValueFunctor( inputFilename,RescalFCT(rescaleInputMin,
+                                                                                             rescaleInputMax,
+                                                                                             0, 255) );
+  trace.info() << "Imported..."<< std::endl;
 
 
 
-    QApplication application(argc,argv);
-    Viewer3D<> *viewer = new Viewer3D<>();
-    bool usehm = vm.count("hueColorMap");
-    bool usegh = vm.count("gradHotColorMap");
-    bool usegc = vm.count("gradCoolColorMap");
-    
-    MainWindow w(viewer, &image, MainWindow::ColorMapFunctor(usehm? MainWindow::HueshadeCM:
-                                                             usegh? MainWindow::GradientMapHot:
-                                                             usegc? MainWindow::GradientMapCool:
-                                                             MainWindow::Id), 0,0);
-    w.setWindowTitle ( QString("sliceViewer"));
-    w.updateSliceImageX( image.domain().lowerBound()[0], true);
-    w.updateSliceImageY( image.domain().lowerBound()[1], true);
-    w.updateSliceImageZ( image.domain().lowerBound()[2], true);
-    w.show();
-    Z3i::Point size = image.domain().upperBound() - image.domain().lowerBound();
-    Z3i::Point center = image.domain().lowerBound()+size/2;
-    unsigned int maxDist = std::max(std::max(size[2], size[1]), size[2]);
-    viewer->camera()->setPosition(qglviewer::Vec(center[0],center[1], 
-                                                 center[2] + 2.0*maxDist));
-    viewer->camera()->setSceneCenter(qglviewer::Vec(center[0],center[1],center[2]));
-    application.exec();
-    delete viewer;
-  }
+  
+
+  QApplication application(argc,argv);
+  Viewer3D<> *viewer = new Viewer3D<>();
+  bool usehm = vm.count("hueColorMap");
+  bool usegh = vm.count("gradHotColorMap");
+  bool usegc = vm.count("gradCoolColorMap");
+  
+  MainWindow w(viewer, &image, MainWindow::ColorMapFunctor(usehm? MainWindow::HueshadeCM:
+                                                           usegh? MainWindow::GradientMapHot:
+                                                           usegc? MainWindow::GradientMapCool:
+                                                           MainWindow::Id), 0,0);
+  w.setWindowTitle ( QString("sliceViewer"));
+  w.updateSliceImageX( image.domain().lowerBound()[0], true);
+  w.updateSliceImageY( image.domain().lowerBound()[1], true);
+  w.updateSliceImageZ( image.domain().lowerBound()[2], true);
+  w.show();
+  Z3i::Point size = image.domain().upperBound() - image.domain().lowerBound();
+  Z3i::Point center = image.domain().lowerBound()+size/2;
+  unsigned int maxDist = std::max(std::max(size[2], size[1]), size[2]);
+  viewer->camera()->setPosition(qglviewer::Vec(center[0],center[1], 
+                                               center[2] + 2.0*maxDist));
+  viewer->camera()->setSceneCenter(qglviewer::Vec(center[0],center[1],center[2]));
+  application.exec();
+  delete viewer;
+
 }
-
 

--- a/visualisation/sliceViewer.cpp
+++ b/visualisation/sliceViewer.cpp
@@ -35,9 +35,6 @@
 #include "DGtal/io/Color.h"
 #include "DGtal/io/DrawWithDisplay3DModifier.h"
 #endif
-#ifdef WITH_ITK
-#include "DGtal/io/readers/DicomReader.h"
-#endif
 
 #include "sliceViewer.h"
 #include "ui_sliceViewer.h"
@@ -72,17 +69,21 @@ namespace po = boost::program_options;
    @b Allowed @b options @b are :
  
    @code
-   -h [ --help ]           display this message
-   -i [ --input ] arg      vol file (.vol, .longvol .p3d, .pgm3d and if 
-                           WITH_ITK is selected: dicom, dcm, mha, mhd) or 
-                           sdp (sequence of discrete points). For longvol, 
-                           dicom, dcm, mha or mhd formats, the input values
-                           are linearly scaled between 0 and 255.
-   --hueColorMap           use hue color map to display images.
-   --gradHotColorMap       use hot gradient color map to display images.
-   --gradCoolColorMap      use cool gradient color map to display images.
-   --dicomMin arg (=-1000) set minimum density threshold on Hounsfield scale
-   --dicomMax arg (=3000)  set maximum density threshold on Hounsfield scale
+   -h [ --help ]                     display this message
+   -i [ --input ] arg                vol file (.vol, .longvol .p3d, .pgm3d and if 
+                                     WITH_ITK is selected: dicom, dcm, mha, mhd) or 
+                                     sdp (sequence of discrete points). For longvol, 
+                                     dicom, dcm, mha or mhd formats, the input values
+                                     are linearly scaled between 0 and 255.
+   --hueColorMap                     use hue color map to display images.
+   --gradHotColorMap                 use hot gradient color map to display images.
+   --gradCoolColorMap                use cool gradient color map to display images.
+   --rescaleInputMin arg (=0)        min value used to rescale the input 
+                                     intensity (to avoid basic cast into 8  
+                                     bits image).
+   --rescaleInputMax arg (=255)       max value used to rescale the input 
+                                     intensity (to avoid basic cast into 8 bits
+                                     image).
    @endcode
 
    @b Example: 

--- a/visualisation/sliceViewer.cpp
+++ b/visualisation/sliceViewer.cpp
@@ -73,8 +73,11 @@ namespace po = boost::program_options;
  
    @code
    -h [ --help ]           display this message
-   -i [ --input ] arg      vol file (.vol) , pgm3d (.p3d or .pgm3d, pgm (with 3 
-   dims)) file or sdp (sequence of discrete points)
+   -i [ --input ] arg      vol file (.vol, .longvol .p3d, .pgm3d and if 
+                           WITH_ITK is selected: dicom, dcm, mha, mhd) or 
+                           sdp (sequence of discrete points). For longvol, 
+                           dicom, dcm, mha or mhd formats, the input values
+                           are linearly scaled between 0 and 255.
    --hueColorMap           use hue color map to display images.
    --gradHotColorMap       use hot gradient color map to display images.
    --gradCoolColorMap      use cool gradient color map to display images.

--- a/visualisation/specificClasses/Viewer3DImage.cpp
+++ b/visualisation/specificClasses/Viewer3DImage.cpp
@@ -39,6 +39,7 @@ template < typename Space, typename KSpace>
 void
 Viewer3DImage< Space, KSpace>::init(){
    DGtal::Viewer3D<>::init();
+
    QGLViewer::setKeyDescription ( Qt::Key_X, "Change the current axis to X for the current 2D image slice setting." );
    QGLViewer::setKeyDescription ( Qt::Key_Y, "Change the current axis to Y for the current 2D image slice setting." );
    QGLViewer::setKeyDescription ( Qt::Key_Z, "Change the current axis to Z for the current 2D image slice setting." );
@@ -117,9 +118,8 @@ Viewer3DImage< Space, KSpace>::setVolImage(Image3D * an3DImage){
   MyRotatorSliceImageAdapter sliceImageZ( *my3dImage, domain2DZ, aSliceFunctorZ, identityFunctor ); 
   (*this) << sliceImageZ;
   (*this) << DGtal::UpdateImagePosition< Space, KSpace > (2, DGtal::Viewer3D<>::zDirection, myImageOrigin[0], myImageOrigin[1], mySliceZPos);
-
-    
-  (*this) << DGtal::Viewer3D<>::updateDisplay;
+  (*this) << DGtal::Viewer3D<>::updateDisplay;    
+  
 }
 
 


### PR DESCRIPTION
 PR Description
Add longvol in various readers.
In progress, todo:
 - [x] 3dImageViewer
 - [x] sliceViewer
 - [x] 3dVolViewer
 - [x] vol2sdp
 - [x] vol2obj
 - [x] vol2slice
 - [x] vol2raw 
 - [x] vol2heightfield
 - [x] volBoundary2obj

# Checklist

- [x] Doxygen documentation of the code completed (classes, methods, types, members...).
- [x] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [x] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).