### PR TITLE
add option for ambient light in meshViewer

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,8 +4,8 @@
   - Improve visualisation tools (vol2heightfield, vol2obj, vol2raw, vol2sdp, vol2slice, volBoundary2obj, 3dImageViewer, 3dVolViewer, sliceViewer, Viewer3DImage)
     allowing to read longvol including rescaling.
     (Bertrand Kerautret, [#296](https://github.com/DGtal-team/DGtalTools/pull/296))
-
-
+  - meshViewer: add an option to set the ambient light source.
+    (Bertrand Kerautret, [#301](https://github.com/DGtal-team/DGtalTools/pull/301))
 
 # DGtalTools 0.9.3
 

--- a/visualisation/meshViewer.cpp
+++ b/visualisation/meshViewer.cpp
@@ -87,6 +87,9 @@ using namespace DGtal;
                                    discrete points (used with displaySDP 
                                    option)
   -n [ --invertNormal ]            threshold min to define binary shape
+  -A [ --addAmbientLight ] arg(=0) add an ambient light for better display 
+                                   (between 0 and 1).
+
   -v [ --drawVertex ]              draw the vertex of the mesh
   -d [ --doSnapShotAndExit]  arg,  save display snapshot into file. Notes that the camera setting is set by default according the last saved configuration (use SHIFT+Key_M to save current camera setting in the Viewer3D). If the camera setting was not saved it will use the default camera setting.
 
@@ -175,9 +178,10 @@ int main( int argc, char** argv )
   ("displayVectorField,f",po::value<std::string>(),  "display a vector field from a simple sdp file (two points per line)" )
   ("vectorFieldIndex",po::value<std::vector<unsigned int> >()->multitoken(), "specify special indices for the two point coordinates (instead usinf the default indices: 0 1, 2, 3, 4, 5)" )
   ("customLineColor",po::value<std::vector<unsigned int> >()->multitoken(), "set the R, G, B components of the colors of the lines displayed from the --displayVectorField option (red by default). " )
-  ("displaySDP,s", po::value<std::string>(), "Add the display of a set of discrete points as ball of radius 0.5.")
+  ("displaySDP,s", po::value<std::string>(), "add the display of a set of discrete points as ball of radius 0.5.")
   ("SDPradius", po::value<double>()->default_value(0.5), "change the ball radius to display a set of discrete points (used with displaySDP option)")
   ("invertNormal,n", "invert face normal vectors." )
+  ("addAmbientLight,A",po:: value<float>()->default_value(0.0), "add an ambient light for better display (between 0 and 1)." )
   ("drawVertex,v", "draw the vertex of the mesh" )
   ("doSnapShotAndExit,d", po::value<std::string>(), "save display snapshot into file. Notes that the camera setting is set by default according the last saved configuration (use SHIFT+Key_M to save current camera setting in the Viewer3D). If the camera setting was not saved it will use the default camera setting." );
   
@@ -289,16 +293,21 @@ int main( int argc, char** argv )
   if(vm.count("doSnapShotAndExit")){
     viewer.setSnapshotFileName(QString(vm["doSnapShotAndExit"].as<std::string>().c_str()));
   }
+
   std::stringstream title;
   title  << "Simple Mesh Viewer: " << inputFilenameVect[0];
   viewer.setWindowTitle(title.str().c_str());
   viewer.show();
   viewer.myGLLineMinWidth = lineWidth;
   viewer.setGLScale(sx, sy, sz);
-  bool invertNormal= vm.count("invertNormal");
-  
-  
+  bool invertNormal= vm.count("invertNormal");  
   double ballRadius = vm["SDPradius"].as<double>();
+  if(vm.count("addAmbientLight"))
+    {
+      float val = vm["addAmbientLight"].as<float>();
+      GLfloat lightAmbientCoeffs [4] = {val,val, val, 1.0f};
+      viewer.setGLLightAmbientCoefficients(lightAmbientCoeffs);
+    }
   
   trace.info() << "Importing mesh... ";
   

--- a/visualisation/meshViewer.cpp
+++ b/visualisation/meshViewer.cpp
@@ -138,9 +138,13 @@ protected:
     {
       handled=true;
       myIsDisplayingInfoMode = !myIsDisplayingInfoMode;
-      std::stringstream sstring;
+      stringstream ss;
+      qglviewer::Vec camPos = camera()->position();
+      DGtal::Z3i::RealPoint c (camPos[0], camPos[1], camPos[2]);
+      ss << myInfoDisplay << "distance to camera: " << (c-centerMesh).norm();
       Viewer3D<>::displayMessage(QString(myIsDisplayingInfoMode ?
-                                                      myInfoDisplay.c_str() : " "), 1000000);
+                                         ss.str().c_str() : " "), 1000000);
+      
       Viewer3D<>::updateGL();
     }
     if(!handled)
@@ -153,6 +157,7 @@ public:
   std::string myInfoDisplay = "No information loaded...";
   bool myIsDisplayingInfoMode = false;
   bool mySaveSnap = false;
+  DGtal::Z3i::RealPoint centerMesh;
 };
 
 
@@ -317,8 +322,16 @@ int main( int argc, char** argv )
     aMesh << inputFilenameVect[i];
     vectMesh.push_back(aMesh);
   }
-  
-  
+  DGtal::Z3i::RealPoint centerMeshes;
+  unsigned int tot=0;
+  for(const auto & m: vectMesh)
+    {
+      for( auto p = m.vertexBegin(); p!=m.vertexEnd(); ++p)
+        centerMeshes += *p;
+      tot+=m.nbVertex();
+    }
+  centerMeshes /= tot;
+  viewer.centerMesh = centerMeshes;
   bool import = vectMesh.size()==inputFilenameVect.size();
   if(!import){
     trace.info() << "File import failed. " << std::endl;
@@ -381,7 +394,7 @@ int main( int argc, char** argv )
       nbFaces +=m.nbFaces();
     }
   stringstream ss;
-  ss << "# faces: " << std::fixed << nbFaces << "    #vertex: " <<  nbVertex;
+  ss << "# faces: " << std::fixed << nbFaces << "    #vertex: " <<  nbVertex ;
   viewer.myInfoDisplay = ss.str();
   viewer  << CustomViewer3D::updateDisplay;
   if(vm.count("doSnapShotAndExit")){

--- a/visualisation/meshViewer.cpp
+++ b/visualisation/meshViewer.cpp
@@ -141,7 +141,7 @@ protected:
       stringstream ss;
       qglviewer::Vec camPos = camera()->position();
       DGtal::Z3i::RealPoint c (camPos[0], camPos[1], camPos[2]);
-      ss << myInfoDisplay << "distance to camera: " << (c-centerMesh).norm();
+      ss << myInfoDisplay << " distance to camera: " << (c-centerMesh).norm();
       Viewer3D<>::displayMessage(QString(myIsDisplayingInfoMode ?
                                          ss.str().c_str() : " "), 1000000);
       


### PR DESCRIPTION
# PR Description
Small just to improve display with option to add ambient light source (better for transparent object)

# Checklist

- [x] Doxygen documentation of the code completed (classes, methods, types, members...).
- [x] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [x] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).