### PR TITLE
option to display unit vector

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@
     (Bertrand Kerautret, [#296](https://github.com/DGtal-team/DGtalTools/pull/296))
   - meshViewer: add an option to set the ambient light source.
     (Bertrand Kerautret, [#301](https://github.com/DGtal-team/DGtalTools/pull/301))
-  - 3dSDPViewer: new option to display vector field as unit vector
+  - 3dSDPViewer: new option to display vector field as unit vectors.
     (Bertrand Kerautret, [#301](https://github.com/DGtal-team/DGtalTools/pull/304))
   
   

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,10 @@
     (Bertrand Kerautret, [#296](https://github.com/DGtal-team/DGtalTools/pull/296))
   - meshViewer: add an option to set the ambient light source.
     (Bertrand Kerautret, [#301](https://github.com/DGtal-team/DGtalTools/pull/301))
-
+  - 3dSDPViewer: new option to display vector field as unit vector
+    (Bertrand Kerautret, [#301](https://github.com/DGtal-team/DGtalTools/pull/304))
+  
+  
 # DGtalTools 0.9.3
 
 - *visualisation*:

--- a/visualisation/3dSDPViewer.cpp
+++ b/visualisation/3dSDPViewer.cpp
@@ -124,6 +124,12 @@ typedef Viewer3D<Z3i::Space, Z3i::KSpace> Viewer;
                                         determined by two consecutive point 
                                         given, each point represented by its 
                                         coordinates on a single line.
+  -u [ --unitVector ] arg (=1)          specifies that the SDP vector file 
+                                        format (of --drawVectors option) should
+                                        be interpreted as unit vectors (each 
+                                        vector position is be defined from the 
+                                        input point (with input order) with a 
+                                        constant norm defined by [arg]).
   --filterVectors arg (=100)            filters vector input file in order to 
                                         display only the [arg] percentage of the 
                                         input vectors (uniformly selected, to 
@@ -217,6 +223,8 @@ int main( int argc, char** argv )
   ("lineSize",  po::value<double>()->default_value(0.2), "defines the line size (used when the --drawLines or --drawVectors option is selected). (default value 0.2))")
   ("primitive,p", po::value<std::string>()->default_value("voxel"), "set the primitive to display the set of points (can be sphere, voxel (default), or glPoints (opengl points).")
   ("drawVectors,v", po::value<std::string>(), "SDP vector file: draw a set of vectors from the given file (each vector are determined by two consecutive point given, each point represented by its coordinates on a single line.")
+  ("unitVector,u", po::value<double>()->default_value(1.0), "specifies that the SDP vector file format (of --drawVectors option) should be interpreted as unit vectors (each vector position is be defined from the input point (with input order) with a constant norm defined by [arg]).")
+
   ("filterVectors",po::value<double>()->default_value(100.0), "filters vector input file in order to display only the [arg] percent of the input vectors (uniformly selected, to be used with option --drawVectors else no effect). " )
  
     ("interactiveDisplayVoxCoords", "by using this option the pixel coordinates can be displayed after selection (shift+left click on voxel)." );
@@ -301,6 +309,9 @@ int main( int argc, char** argv )
   bool importColorLabels = vm.count("importColorLabels");
   bool importColors = vm.count("importColors");
   bool interactiveDisplayVoxCoords = vm.count("interactiveDisplayVoxCoords");
+  bool useUnitVector = vm.count("unitVector");
+  double constantNorm = vm["unitVector"].as<double>();
+  
   typedef Viewer3D<Z3i::Space, Z3i::KSpace> Viewer;
   Z3i::KSpace K;
   Viewer viewer( K );
@@ -433,9 +444,16 @@ int main( int argc, char** argv )
           double percentage = vm["filterVectors"].as<double>();
           step = max(1, (int) (100/percentage));
         }
-      for(unsigned int i =0; i<vectorsPt.size()-1; i=i+2*step)
-      {
-        viewer.addLine(vectorsPt.at(i),vectorsPt.at(i+1), lineSize);
+      if(useUnitVector){
+        for(unsigned int i =0; i< std::min(vectVoxels.size(), vectorsPt.size()); i=i+2*step)
+          {
+            viewer.addLine(vectVoxels.at(i), vectVoxels.at(i)+vectorsPt.at(i)*constantNorm, lineSize);
+          }
+      }else{
+        for(unsigned int i =0; i<vectorsPt.size()-1; i=i+2*step)
+          {
+            viewer.addLine(vectorsPt.at(i),vectorsPt.at(i+1), lineSize);
+          }
       }
       
     }

--- a/visualisation/3dSDPViewer.cpp
+++ b/visualisation/3dSDPViewer.cpp
@@ -444,25 +444,30 @@ int main( int argc, char** argv )
           double percentage = vm["filterVectors"].as<double>();
           step = max(1, (int) (100/percentage));
         }
-      if(useUnitVector){
+      if(useUnitVector)
+      {
         for(unsigned int i =0; i< std::min(vectVoxels.size(), vectorsPt.size()); i=i+2*step)
-          {
-            viewer.addLine(vectVoxels.at(i), vectVoxels.at(i)+vectorsPt.at(i)*constantNorm, lineSize);
-          }
-      }else{
+        {
+          viewer.addLine(vectVoxels.at(i), vectVoxels.at(i)+vectorsPt.at(i)*constantNorm, lineSize);
+        }
+      }
+      else
+      {
         for(unsigned int i =0; i<vectorsPt.size()-1; i=i+2*step)
-          {
-            viewer.addLine(vectorsPt.at(i),vectorsPt.at(i+1), lineSize);
-          }
+        {
+          viewer.addLine(vectorsPt.at(i),vectorsPt.at(i+1), lineSize);
+        }
       }
       
     }
     if(vm.count("addMesh"))
     {
       bool customColorMesh =  vm.count("customColorMesh");
-      if(customColorMesh){
+      if(customColorMesh)
+      {
         std::vector<unsigned int > vectCol = vm["customColorMesh"].as<std::vector<unsigned int> >();
-        if(vectCol.size()!=4){
+        if(vectCol.size()!=4)
+        {
           trace.error() << "colors specification should contain R,G,B and Alpha values"<< std::endl;
         }
         viewer.setFillColor(DGtal::Color(vectCol[0], vectCol[1], vectCol[2], vectCol[3]));


### PR DESCRIPTION
# PR Description
Just a small option to adapt format of vector field.

# Checklist

- [x] Doxygen documentation of the code completed (classes, methods, types, members...).
- [x] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [x] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
