### PR TITLE
fix for qglviewer 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ addons:
     - libgmp-dev
     - libgdcm2-dev
     - libgraphicsmagick++1-dev
-    - libqglviewer-qt4-dev
+    - libqglviewer-dev
     - libinsighttoolkit3-dev
     - g++-4.8
     - gcc-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ before_install:
   - export BOOST_DOWNLOAD_URL="http://ker.iutsd.univ-lorraine.fr/boost.tar.bz2"
   - export BOOST_ROOT="$TRAVIS_BUILD_DIR/../boost"
   - export CMAKE_MODULE_PATH="$BOOST_ROOT"
-  - if [ ! -f "$DOWNLOAD_ROOT/boost.tar.bz2" ]; then wget --no-verbose --output-document="$DOWNLOAD_ROOT/boost.tar.bz2" "$BOOST_DOWNLOAD_URL"; fi
+  - if [ ! -f "$DOWNLOAD_ROOT/boost.tar.bz2" ]; then wget --output-document="$DOWNLOAD_ROOT/boost.tar.bz2" "$BOOST_DOWNLOAD_URL"; fi
   - if [ ! -d "$BOOST_ROOT" ]; then mkdir -p "$BOOST_ROOT" && tar jxf "$DOWNLOAD_ROOT/boost.tar.bz2" --strip-components=1 -C "$BOOST_ROOT"; fi
   - if [ ! -f "$BOOST_ROOT/b2" ]; then cd "$BOOST_ROOT"; ./bootstrap.sh --with-toolset="$BOOST_TOOLSET" --with-libraries=program_options; fi
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,8 @@
 - *global*:
   - Fix travis with boost installation which now use std package.
     (Bertrand Kerautret, [#310](https://github.com/DGtal-team/pull/310))
+  - Fix for the last QGLViewer version (2.7).
+    (Bertrand Kerautret, [#310](https://github.com/DGtal-team/pull/308))
 
   
   

--- a/visualisation/3dVolViewer.cpp
+++ b/visualisation/3dVolViewer.cpp
@@ -253,7 +253,7 @@ int main( int argc, char** argv )
     // Appy cleaning just save the last snap
     if(!viewer.restoreStateFromFile())
       {
-        viewer.updateGL();
+        viewer.update();
       }    
     std::string name = vm["doSnapShotAndExit"].as<std::string>();
     std::string extension = name.substr(name.find_last_of(".") + 1);

--- a/visualisation/meshViewer.cpp
+++ b/visualisation/meshViewer.cpp
@@ -145,8 +145,9 @@ protected:
       Viewer3D<>::displayMessage(QString(myIsDisplayingInfoMode ?
                                          ss.str().c_str() : " "), 1000000);
       
-      Viewer3D<>::updateGL();
+      Viewer3D<>::update();
     }
+    
     if(!handled)
       {
         Viewer3D<>::keyPressEvent(e);        
@@ -401,7 +402,7 @@ int main( int argc, char** argv )
     // Appy cleaning just save the last snap
     if(!viewer.restoreStateFromFile())
       {
-        viewer.updateGL();
+        viewer.update();
       }    
     std::string name = vm["doSnapShotAndExit"].as<std::string>();
     std::string extension = name.substr(name.find_last_of(".") + 1);
@@ -412,6 +413,7 @@ int main( int argc, char** argv )
       trace.info() << "erase temp file: " << s.str() << std::endl;
       remove(s.str().c_str());
     }
+
     std::stringstream s;
     s << basename << "-"<< setfill('0') << setw(4)<<  viewer.snapshotCounter()-1 << "." << extension;
     rename(s.str().c_str(), name.c_str());


### PR DESCRIPTION
# PR Description

Like the previous DGtal PR [#1281](https://github.com/DGtal-team/DGtal/pull/1281) it allows to compile the tools using the last version of qglviewer.


# Checklist

- [x] Doxygen documentation of the code completed (classes, methods, types, members...).
- [x] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [x] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).