### PR TITLE
Fix travis dox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ compiler:
   - gcc
   - clang
 
+cache: apt
+
+
 env:
   - CONFIG="Debug,QGLVIEWER"
   - CONFIG="Debug"
@@ -32,8 +35,6 @@ addons:
    packages:
     - libhdf5-serial-dev
     - libcairo2-dev
-    - doxygen
-    - doxygen-latex
     - graphviz
     - libgmp-dev
     - libgdcm2-dev
@@ -48,7 +49,7 @@ addons:
 
 
 before_install:
-  - DOC="false"
+  - DOC="false"; BTYPE=""
   - if [ $CONFIG == "DOCUMENTATION" ]; then if [ $OriginalRepo == "true" ];  then if [ $TRAVIS_PULL_REQUEST == "false" ]; then DOC="true"; fi; fi; fi
   - if [ $DOC == true ];then   openssl aes-256-cbc -K $encrypted_a0b8e3011fca_key -iv $encrypted_a0b8e3011fca_iv -in .travis/dgtal_rsa.enc -out .travis/dgtal_rsa -d ; chmod 600 .travis/dgtal_rsa; fi
   - env
@@ -69,11 +70,13 @@ before_script:
   - cmake . $DGTALTYPE -DCMAKE_CXX_COMPILER=$CXXCOMPILER -DCMAKE_C_COMPILER=$CCOMPILER 
   - make
   - cd ..
-  - if [ $DOC == "true" ]; then .travis/install_doxygen.sh;  BTYPE="-DDOXYGEN_EXECUTABLE=$HOME/doxygen/doxygen-1.8.10/bin/doxygen -DCMAKE_BUILD_TYPE=Debug -DWITH_CAIRO=true  -DWITH_GMP=true"; DOC="true"; fi
+  - if [ $DOC == "true" ]; then .travis/install_doxygen.sh;  BTYPE="-DDOXYGEN_EXECUTABLE=$HOME/doxygen/doxygen-1.8.10/bin/doxygen -DCMAKE_BUILD_TYPE=Debug -DWITH_CAIRO=true  -DWITH_GMP=true";  fi
   - if [ $DOC == "true" ]; then wget http://http://dgtal.org/doc/tags/DGtal-tagfile; wget http://http://dgtal.org/doc/tags/Board-tagfile;fi
 
+
+
 script:
-   - cmake . -DDGtal_DIR=$PWD/DGtal -DDOXYGEN_EXECUTABLE=$HOME/doxygen/doxygen-1.8.10/bin/doxygen  -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=$CXXCOMPILER -DCMAKE_C_COMPILER=$CCOMPILER 
+   - cmake . -DDGtal_DIR=$PWD/DGtal $BTYPE  -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=$CXXCOMPILER -DCMAKE_C_COMPILER=$CCOMPILER 
    - if [ $DOC == "true" ]; then  make doc;  rsync -azv --delete --delete-after -e 'ssh -oStrictHostKeyChecking=no -i  .travis/dgtal_rsa' html/ dgtal@liris.cnrs.fr:/home/dgtal/public_html/doc/tools/nightly/;  fi
    - if [ $CONFIG == "Debug" ]; then make; fi
    - if [ $CONFIG == "Debug,QGLVIEWER" ]; then make; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ addons:
 before_install:
   - DOC="false"; BTYPE=""
   - if [ $CONFIG == "DOCUMENTATION" ]; then if [ $OriginalRepo == "true" ];  then if [ $TRAVIS_PULL_REQUEST == "false" ]; then DOC="true"; fi; fi; fi
-  - if [ $DOC == true ];then   openssl aes-256-cbc -K $encrypted_a0b8e3011fca_key -iv $encrypted_a0b8e3011fca_iv -in .travis/dgtal_rsa.enc -out .travis/dgtal_rsa -d ; chmod 600 .travis/dgtal_rsa; fi
+  - if [ $DOC == "true" ]; then openssl aes-256-cbc -K $encrypted_47769ec71275_key -iv $encrypted_47769ec71275_iv -in .travis/dgtal_rsa.enc -out .travis/dgtal_rsa -d; chmod 600 .travis/dgtal_rsa; fi
   - env
   - export SRC_DIR="`pwd`"
   - if [ $CXX == "g++" ]; then export CXX="g++-4.8"  CC="gcc-4.8"  CCOMPILER="gcc-4.8" CXXCOMPILER="g++-4.8"; fi
@@ -83,4 +83,4 @@ script:
 
 after_success:
   ## We publish the DGtalTools tags
-  - if [ $DOC == "true" ]; then scp -i  .travis/dgtal_rsa  DGtalTools-tagfile dgtal@liris.cnrs.fr:/home/dgtal/public_html/doc/tags; fi
+  - if [ $DOC == "true" ]; then echo "Uploading the doc..."; .travis/publish_doc.sh;  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ before_script:
 
 script:
    - cmake . -DDGtal_DIR=$PWD/DGtal $BTYPE  -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=$CXXCOMPILER -DCMAKE_C_COMPILER=$CCOMPILER 
-   - if [ $DOC == "true" ]; then  make doc; 
+   - if [ $DOC == "true" ]; then  make doc;  fi
    - if [ $CONFIG == "Debug" ]; then make; fi
    - if [ $CONFIG == "Debug,QGLVIEWER" ]; then make; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ before_script:
 
 script:
    - cmake . -DDGtal_DIR=$PWD/DGtal $BTYPE  -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=$CXXCOMPILER -DCMAKE_C_COMPILER=$CCOMPILER 
-   - if [ $DOC == "true" ]; then  make doc;  rsync -azv --delete --delete-after -e 'ssh -oStrictHostKeyChecking=no -i  .travis/dgtal_rsa' html/ dgtal@liris.cnrs.fr:/home/dgtal/public_html/doc/tools/nightly/;  fi
+   - if [ $DOC == "true" ]; then  make doc; 
    - if [ $CONFIG == "Debug" ]; then make; fi
    - if [ $CONFIG == "Debug,QGLVIEWER" ]; then make; fi
 

--- a/.travis/publish_doc.sh
+++ b/.travis/publish_doc.sh
@@ -4,6 +4,6 @@ set -ev
 
 cd build/
 echo $HOME
-rsync -azv --delete --delete-after -e 'ssh -oStrictHostKeyChecking=no -i  /home/travis/build/DGtal-team/DGtal/.travis/dgtal_rsa' html/ dgtal@liris.cnrs.fr:/home/dgtal/public_html/doc/tools/
+rsync -azv --delete --delete-after -e 'ssh -oStrictHostKeyChecking=no -i  /home/travis/build/DGtal-team/DGtalTools/.travis/dgtal_rsa' html/ dgtal@liris.cnrs.fr:/home/dgtal/public_html/doc/tools/nightly
 
 

--- a/.travis/publish_doc.sh
+++ b/.travis/publish_doc.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -ev
+
+cd build/
+echo $HOME
+rsync -azv --delete --delete-after -e 'ssh -oStrictHostKeyChecking=no -i  /home/travis/build/DGtal-team/DGtal/.travis/dgtal_rsa' html/ dgtal@liris.cnrs.fr:/home/dgtal/public_html/doc/tools/
+
+

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,8 @@
 
 
 - *global*:
+  - Fix travis Doxygen compilation for non Documention mode.
+    (Bertrand Kerautret, [#314](https://github.com/DGtal-team/DGtalTools/pull/314))
   - Fix travis with boost installation which now use std package.
     (Bertrand Kerautret, [#310](https://github.com/DGtal-team/DGtalTools/pull/310))
   - Fix for the last QGLViewer version (2.7).


### PR DESCRIPTION
# PR Description
Fix travis Doxygen compilation for non Documention mode. (it was failing from some time)

# Checklist
- [x] Doxygen documentation of the code completed (classes, methods, types, members...).
- [x] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [x] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
