### PR TITLE
Fixing trace in volBoundary2obj

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,8 @@
 - *converters*
    - volAddNoise moved to ```volumetric/```. (David  Coeurjolly,
    [#300](https://github.com/DGtal-team/pull/300))
+   - segfault fix in volBoundary2obj (David Coeurjolly,
+   [#300](https://github.com/DGtal-team/pull/300))
 
 - *volumetric*
    - new option to volAddNoise to extract the largest 6-connected

--- a/converters/volBoundary2obj.cpp
+++ b/converters/volBoundary2obj.cpp
@@ -168,7 +168,8 @@ int main( int argc, char** argv )
   
   DGtal::int64_t rescaleInputMin = vm["rescaleInputMin"].as<DGtal::int64_t>();
   DGtal::int64_t rescaleInputMax = vm["rescaleInputMax"].as<DGtal::int64_t>();
-  
+
+  trace.beginBlock( "Loading file.." );
   typedef DGtal::functors::Rescaling<DGtal::int64_t ,unsigned char > RescalFCT;
   Image image =  GenericReader< Image >::importWithValueFunctor( inputFilename,RescalFCT(rescaleInputMin,
                                                                                          rescaleInputMax,


### PR DESCRIPTION
# PR Description

Fixing segfault in volBoiundary2obj

# Checklist

- [ ] Doxygen documentation of the code completed (classes, methods, types, members...).
- [ ] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [ ] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [ ] Update the readme with potentially a screenshot of the tools if it applies. 
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
