### PR TITLE
fix volBoundary2Obj surfels orientation

### DIFF
--- a/converters/volBoundary2obj.cpp
+++ b/converters/volBoundary2obj.cpp
@@ -212,11 +212,32 @@ int main( int argc, char** argv )
   Board3D<Space,KSpace> board(ks);
 
   board << SetMode3D(  ks.unsigns( *digSurf.begin() ).className(), "Basic" );
+  board << SetMode3D(  (*digSurf.begin()).className(), "Basic" );
 
   typedef MyDigitalSurface::ConstIterator ConstIterator;
   if ( mode == "BDRY" )
     for ( ConstIterator it = digSurf.begin(), itE = digSurf.end(); it != itE; ++it )
-      board << ks.unsigns( *it );
+    { 
+      //board << ks.unsigns( *it );
+      bool indirectFilled = thresholdedImage(ks.sCoords( ks.sIndirectIncident( *it, ks.sOrthDir( *it ) ) ));
+      bool directFilled = thresholdedImage(ks.sCoords( ks.sDirectIncident( *it, ks.sOrthDir( *it ) ) ));
+      Z3i::RealPoint sc = board.embedKS(*it);
+      Z3i::RealPoint n (0,0,0);
+      auto ip = ks.sCoords( ks.sIndirectIncident( *it, ks.sOrthDir( *it ) ) );  
+      if (!indirectFilled)
+      {
+        ip = ks.sCoords( ks.sDirectIncident( *it, ks.sOrthDir( *it ) ) );
+      }
+      n = sc - Z3i::RealPoint(static_cast<Z3i::RealPoint::Component>(ip[0]),
+                              static_cast<Z3i::RealPoint::Component>(ip[1]),
+                              static_cast<Z3i::RealPoint::Component>(ip[2]));
+      bool xodd = ks.sIsOpen( *it, 0 );
+      bool yodd = ks.sIsOpen( *it, 1 );
+      bool zodd = ks.sIsOpen( *it, 2 );      
+      board.addQuadFromSurfelCenterWithNormal
+        ( Z3i::RealPoint( sc[0]+(xodd? 0:0.5 ), sc[1]+(yodd? 0:0.5 ), sc[2]+(zodd? 0:0.5 ) ),
+          ! xodd, ! yodd, ! zodd, n, true,  true, false );
+    }
   else if ( mode == "INNER" )
     for ( ConstIterator it = digSurf.begin(), itE = digSurf.end(); it != itE; ++it )
       board << ks.sCoords( ks.sDirectIncident( *it, ks.sOrthDir( *it ) ) );
@@ -224,8 +245,8 @@ int main( int argc, char** argv )
     for ( ConstIterator it = digSurf.begin(), itE = digSurf.end(); it != itE; ++it )
       board << ks.sCoords( ks.sIndirectIncident( *it, ks.sOrthDir( *it ) ) );
   else  if (mode == "CLOSURE")
-    {
-      std::set<KSpace::Cell> container;
+  {
+    std::set<KSpace::Cell> container;
       for ( ConstIterator it = digSurf.begin(), itE = digSurf.end(); it != itE; ++it )
         {
           container.insert( ks.unsigns( *it ) );


### PR DESCRIPTION
# PR Description
Fixing issue #320 now produce good display without DGtal change:
<img width="796" alt="capture d ecran 2018-03-04 a 16 24 34" src="https://user-images.githubusercontent.com/772865/36947159-8dc74444-1fc8-11e8-80a3-457871c64223.png">


# Checklist

- [ ] Doxygen documentation of the code completed (classes, methods, types, members...).
- [ ] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [ ] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [ ] Update the readme with potentially a screenshot of the tools if it applies. 
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).