### PR TITLE
Bugfix parsing options in regularization

### DIFF
--- a/estimators/volSurfaceRegularization.cpp
+++ b/estimators/volSurfaceRegularization.cpp
@@ -123,8 +123,7 @@ parse_options(int argc, char* argv[])
     Options options;
     po::options_description po_shape("File options");
     po_shape.add_options()
-        ("image-filename,i", po::value<std::string>(&options.image_filename)->default_value(""), "input vol filename for image shape (object voxels
-                                        have values > 0) or input cvs filename for surfels and normals")
+        ("image-filename,i", po::value<std::string>(&options.image_filename)->default_value(""), "input vol filename for image shape (object voxels have values > 0) or input cvs filename for surfels and normals")
         ("regularized-obj-filename,o", po::value<std::string>(&options.regularized_obj_filename)->default_value(""), "output regularized obj")
         ("cubical-obj-filename,n", po::value<std::string>(&options.cubical_obj_filename)->default_value(""), "output cubical obj")
         ("shape-noise,k", po::value<double>(&options.noise_level)->default_value(0), "noise shape parameter")


### PR DESCRIPTION
# PR Description

Reported bug from @copyme . The release does not compile with this bug.

# Checklist

- [x] Doxygen documentation of the code completed (classes, methods, types, members...).
- [x] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [x] Update the readme with potentially a screenshot of the tools if it applies. 
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).