### PR TITLE
[WIP] Fixing PointVector implicit conversions (in link with DGtal PR #1345)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,6 @@
 # DGtalTools 1.0
 
-- *global*:
+- *global*
     - Continuous integration AppVeyor fix.
       (Bertrand Kerautret, [#337](https://github.com/DGtal-team/DGtalTools/pull/337)).
 - *volumetric*
@@ -9,7 +9,7 @@
     - Update Critical Kernels thinning using VoxelComplex, following
       [recent changes in DGtal](https://github.com/DGtal-team/DGtal/pull/1369).
       (Pablo Hernandez, [#345](https://github.com/DGtal-team/DGtalTools/pull/345))
- 
+
 # DGtalTools 0.9.4
 
 - *converters*
@@ -26,7 +26,7 @@
    [#317](https://github.com/DGtal-team/DGtalTools/pull/317))
    - Fix the bad surfel display of volBoundary2obj (issue #320)
    (Bertrand Kerautret, [#321](https://github.com/DGtal-team/DGtalTools/pull/321))
-   
+
 - *volumetric*
    - new option to volAddNoise to extract the largest 6-connected
    component. (David  Coeurjolly,
@@ -42,12 +42,12 @@
   - New tool for mesh voxelization from a mesh in input (.off)
     to a volumetric output (vol, pgm3d)
     (Monir Hadji, [#279](https://github.com/DGtal-team/DGtalTools/pull/279)
-  - 2dCompImage : Computes and displays image comparisons (squared and absolute 
-    differences) 
+  - 2dCompImage : Computes and displays image comparisons (squared and absolute
+    differences)
     (Bertrand Kerautret, [#313](https://github.com/DGtal-team/DGtalTools/pull/313))
-  - Improve visualisation tools (vol2heightfield, vol2obj, vol2raw, vol2sdp, 
-    vol2slice,volBoundary2obj,3dImageViewer, 3dVolViewer, sliceViewer, Viewer3DImage) 
-    allowing to read longvol including rescaling. (Bertrand Kerautret, 
+  - Improve visualisation tools (vol2heightfield, vol2obj, vol2raw, vol2sdp,
+    vol2slice,volBoundary2obj,3dImageViewer, 3dVolViewer, sliceViewer, Viewer3DImage)
+    allowing to read longvol including rescaling. (Bertrand Kerautret,
     [#296](https://github.com/DGtal-team/DGtalTools/pull/296))
   - Add an option to filter vector displayed in 3dSDPViewer.
    (Bertrand Kerautret, [#297](https://github.com/DGtal-team/DGtalTools/pull/297))

--- a/converters/img2freeman.cpp
+++ b/converters/img2freeman.cpp
@@ -181,8 +181,8 @@ void saveSelContoursAsFC(std::vector< std::vector< Z2i::Point >  >  vectContours
 
   for(unsigned int k=0; k<vectContoursBdryPointels.size(); k++){
     if(vectContoursBdryPointels.at(k).size()>minSize){
-      Z2i::Point ptMean = ContourHelper::getBarycenter(vectContoursBdryPointels.at(k));
-      unsigned int distance = (unsigned int)ceil(sqrt((double)(ptMean[0]-refPoint[0])*(ptMean[0]-refPoint[0])+
+      Z2i::RealPoint ptMean = ContourHelper::getBarycenter(vectContoursBdryPointels.at(k));
+      unsigned int distance = (unsigned int)ceil(sqrt((ptMean[0]-refPoint[0])*(ptMean[0]-refPoint[0])+
 						      (ptMean[1]-refPoint[1])*(ptMean[1]-refPoint[1])));
       if(distance<=selectDistanceMax){
 	FreemanChain<Z2i::Integer> fc (vectContoursBdryPointels.at(k));    

--- a/converters/mesh2heightfield.cpp
+++ b/converters/mesh2heightfield.cpp
@@ -37,6 +37,7 @@
 #include "DGtal/io/writers/MeshWriter.h"
 #include "DGtal/images/ConstImageAdapter.h"
 #include "DGtal/kernel/BasicPointFunctors.h"
+#include <DGtal/base/BasicFunctors.h>
 #include "DGtal/math/linalg/SimpleMatrix.h"
 
 #include <boost/program_options/options_description.hpp>
@@ -335,8 +336,9 @@ int main( int argc, char** argv )
   for(unsigned int k=0; k < maxScan; k++)
     {
       trace.progressBar(k, maxScan);
+      Z3i::Point c (ptCenter+normalDir*k, DGtal::functors::Round<>());
       DGtal::functors::Point2DEmbedderIn3D<DGtal::Z3i::Domain >  embedder(meshVolImage.domain(), 
-                                                                          ptCenter+normalDir*k,
+                                                                          c,
                                                                           normalDir,
                                                                           widthImageScan);
       ImageAdapterExtractor extractedImage(meshVolImage, aDomain2D, embedder, idV);

--- a/converters/ofs2off.cpp
+++ b/converters/ofs2off.cpp
@@ -107,7 +107,7 @@ int main( int argc, char** argv )
   string outputFilename = vm["output"].as<std::string>();
 
   // We store the colors
-  Mesh<Display3D<>::BallD3D> anImportedMesh(true);
+  Mesh<Z3i::RealPoint> anImportedMesh(true);
   bool import = anImportedMesh << inputFilename;
   bool exported = anImportedMesh >> outputFilename;
   if(!import || !exported){

--- a/converters/vol2heightfield.cpp
+++ b/converters/vol2heightfield.cpp
@@ -185,7 +185,7 @@ int main( int argc, char** argv )
   int minTh = vm["thresholdMin"].as<int>();
   int maxTh = vm["thresholdMax"].as<int>();
   
-  trace.info() << "Processing image to output file " << outputFilename ; 
+  trace.info() << "Processing image to output file " << outputFilename << std::endl; 
   
   unsigned int widthImageScan = vm["height"].as<unsigned int>();
   unsigned int heightImageScan = vm["width"].as<unsigned int>();
@@ -218,8 +218,9 @@ int main( int argc, char** argv )
   
   unsigned int maxDepthFound = 0;
   for(unsigned int k=0; k < maxScan; k++){
+    Z3i::Point c (ptCenter+normalDir*k, DGtal::functors::Round<>());
     DGtal::functors::Point2DEmbedderIn3D<DGtal::Z3i::Domain >  embedder(inputImage.domain(), 
-                                                                        ptCenter+normalDir*k,
+                                                                        c,
                                                                         normalDir,
                                                                         widthImageScan);
     ImageAdapterExtractor extractedImage(inputImage, aDomain2D, embedder, idV);

--- a/estimators/2dLocalEstimators.cpp
+++ b/estimators/2dLocalEstimators.cpp
@@ -350,18 +350,16 @@ estimation( Estimator & estimator, double h,
  *
  * @return Euclidean radius for the convolver of Integral Invariant estimators
  */
-template< typename ConstIteratorOnPoints, typename Point >
+template< typename ConstIteratorOnPoints, typename RPoint >
 unsigned int suggestedSizeIntegralInvariant( const double h,
-                                             const Point& center,
+                                             const RPoint& center,
                                              const ConstIteratorOnPoints& itb,
                                              const ConstIteratorOnPoints& ite )
 {
-  typedef typename Point::Component TValue;
-
   ConstIteratorOnPoints it = itb;
-  Point p( *it );
-  Point distance = p - center;
-  TValue minRadius = distance.norm();
+  RPoint p( *it );
+  RPoint distance = p - center;
+  auto minRadius = distance.norm();
   ++it;
 
   for ( ; it != ite; ++it )
@@ -831,7 +829,7 @@ computeLocalEstimations( const std::string & filename,
 
           if( optionsII.radius <= 0.0 )
           {
-            optionsII.radius = suggestedSizeIntegralInvariant( h, dig->round( optionsII.center ), pointsRange.begin(), pointsRange.end() );
+            optionsII.radius = suggestedSizeIntegralInvariant( h,  optionsII.center, pointsRange.begin(), pointsRange.end() );
             file << "# Estimated radius: " << optionsII.radius << std::endl;
           }
           double re = optionsII.radius * std::pow( h, optionsII.alpha );

--- a/estimators/volSurfaceRegularization-details/surface_extract.ih
+++ b/estimators/volSurfaceRegularization-details/surface_extract.ih
@@ -10,6 +10,7 @@
 #include <DGtal/geometry/surfaces/estimation/estimationFunctors/ElementaryConvolutionNormalVectorEstimator.h>
 #include <DGtal/geometry/volumes/KanungoNoise.h>
 #include <DGtal/math/ScalarFunctors.h>
+#include <DGtal/geometry/volumes/distance/LpMetric.h>
 
 template <typename Shape>
 Calculus
@@ -119,7 +120,7 @@ computeFaceNormals(const Calculus& calculus, const Shape& shape, const double ra
         typedef KSpace::SurfelSet MySurfelSet;
         typedef DGtal::SetOfSurfels<KSpace, MySurfelSet> MySetOfSurfels;
         typedef DGtal::DigitalSurface<MySetOfSurfels> MyDigitalSurface;
-        typedef DGtal::ExactPredicateLpSeparableMetric<Space,2> MyMetric;
+        typedef DGtal::LpMetric<Space> MyMetric;
         typedef DGtal::CanonicSCellEmbedder<KSpace> MyCanonicSCellEmbedder;
         typedef DGtal::functors::ElementaryConvolutionNormalVectorEstimator<SCell, MyCanonicSCellEmbedder> MySurfelFunctor;
         typedef RealVector::Component MyScalar;
@@ -135,7 +136,7 @@ computeFaceNormals(const Calculus& calculus, const Shape& shape, const double ra
         const MyHatFunctor hat_functor(1., radius);
         const MyCanonicSCellEmbedder canonic_embedder(kspace);
         MySurfelFunctor surfel_functor(canonic_embedder, 1.);
-        const MyMetric metric;
+        const MyMetric metric(2.0);
 
         TrivialNormalEstimator nt_estimator;
         nt_estimator.attach(digital_surface);

--- a/visualisation/3dCurvatureViewer.cpp
+++ b/visualisation/3dCurvatureViewer.cpp
@@ -643,7 +643,7 @@ int main( int argc, char** argv )
             {
               DGtal::Dimension kDim = K.sOrthDir( *abegin2 );
               SCell outer = K.sIndirectIncident( *abegin2, kDim);
-              if ( predicate(embedder(outer)) )
+              if ( predicate(Z3i::Point(embedder(outer),functors::Round<>()) ))
                 {
                   outer = K.sDirectIncident( *abegin2, kDim);
                 }

--- a/visualisation/3dCurvatureViewerNoise.cpp
+++ b/visualisation/3dCurvatureViewerNoise.cpp
@@ -664,7 +664,7 @@ int main( int argc, char** argv )
         {
           DGtal::Dimension kDim = K.sOrthDir( *abegin2 );
           SCell outer = K.sIndirectIncident( *abegin2, kDim);
-          if ( predicate(embedder(outer)) )
+          if ( predicate(Z3i::Point(embedder(outer), functors::Round<>()) ))
             {
               outer = K.sDirectIncident( *abegin2, kDim);
             }

--- a/visualisation/3dVolViewer.cpp
+++ b/visualisation/3dVolViewer.cpp
@@ -229,7 +229,7 @@ int main( int argc, char** argv )
     }else if(extension=="sdp"){
     vector<Z3i::RealPoint> vectVoxels = PointListReader<Z3i::RealPoint>::getPointsFromFile(inputFilename);
     for(unsigned int i=0;i< vectVoxels.size(); i++){
-      viewer << vectVoxels.at(i);
+      viewer << Z3i::Point(vectVoxels.at(i), functors::Round<>());
     }
   }
   if(vm.count("displayMesh")){


### PR DESCRIPTION
# PR Description

See PR [#1345](https://github.com/DGtal-team/DGtal/pull/1345)
In progress:

- [x] `estimators/2dLocalEstimators.cpp`
- [x] `estimators/volSurfaceRegularization.cpp`
- [x] `converters/mesh2heightfield.cpp`
- [x] `converters/img2freeman.cpp`
- [x] `converters/vol2heightfield.cpp`
- [x] `visualisation/3dCurvatureViewerNoise.cpp`
- [x] `visualisation/3dCurvatureViewer.cpp`
- [x] `visualisation/3dVolViewer.cpp`


# Checklist

- [ ] Doxygen documentation of the code completed (classes, methods, types, members...).
- [ ] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [ ] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [ ] Update the readme with potentially a screenshot of the tools if it applies. 
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).