### PR TITLE
Fixing doxygen source url by downloading it from SourceForge

### DIFF
--- a/.travis/install_doxygen.sh
+++ b/.travis/install_doxygen.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 mkdir ~/doxygen && cd ~/doxygen
-wget http://doxygen.nl/files/doxygen-1.8.14.src.tar.gz && tar xzf doxygen-1.8.14.src.tar.gz
+wget https://sourceforge.net/projects/doxygen/files/rel-1.8.14/doxygen-1.8.14.src.tar.gz/download -O doxygen-1.8.14.src.tar.gz \
+  && tar xzf doxygen-1.8.14.src.tar.gz
 cd doxygen-1.8.14 ; mkdir build ; cd build
 cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/doxygen/
 ninja install

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,8 @@
 - *global*
   -  Fix issue of link with boost program option.  (Bertrand Kerautret
     [#356](https://github.com/DGtal-team/DGtalTools/pull/356))
-
+  - Using SourceForge to download doxygen sources during Travis CI jobs.
+    (Roland Denis [#360](https://github.com/DGtal-team/DGtalTools/pull/360))
 
 # DGtalTools 1.0
 


### PR DESCRIPTION
# PR Description

During continuous integration job, downloading doxygen source from http://doxygen.nl/files/doxygen-1.8.14.src.tar.gz results in a 404 error.

Instead on upgrading to 1.8.16 that will probably lead to new warnings/errors and the same download error in few months, this PR rely on SourceForge.

Note: same as in https://github.com/DGtal-team/DGtal/pull/1434
# Checklist

- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
