### PR TITLE
set cmake  based CPP11 check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,16 @@ LINK_DIRECTORIES(${DGTAL_LIBRARY_DIRS})
 SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 message(STATUS "DGtal found.")
 
+
+
+ # -----------------------------------------------------------------------------
+ # CPP11 
+ # -----------------------------------------------------------------------------
+ set (CMAKE_CXX_STANDARD 11)
+ set (CMAKE_CXX_STANDARD_REQUIRED TRUE)
+
+
+
 # -------------------------------------------------------------------------
 # This test is for instance used for ITK v3.x. ITK forces a limited
 # template depth. We remove this option.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,9 +2,9 @@
 
 - *global*
   -  Fix issue of link with boost program option.  (Bertrand Kerautret
-    [#356](https://github.com/DGtal-team/DGtalTools/pull/356)
-  - set cmake  based CPP11 check instead the manual DGtal check
-    [#364](https://github.com/DGtal-team/DGtalTools/pull/364)
+    [#356](https://github.com/DGtal-team/DGtalTools/pull/356))
+  - set cmake  based CPP11 check instead the manual DGtal check. (Bertrand
+    Kerautret [#364](https://github.com/DGtal-team/DGtalTools/pull/364))
 
 - *volumetric:
   - Passing argument by const reference in (min|max|mean)Val of volSubSample.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,9 @@
 
 - *global*
   -  Fix issue of link with boost program option.  (Bertrand Kerautret
-    [#356](https://github.com/DGtal-team/DGtalTools/pull/356))
+    [#356](https://github.com/DGtal-team/DGtalTools/pull/356)
+  - set cmake  based CPP11 check instead the manual DGtal check
+    [#364](https://github.com/DGtal-team/DGtalTools/pull/364)
 
 - *volumetric:
   - Passing argument by const reference in (min|max|mean)Val of volSubSample.


### PR DESCRIPTION
# PR Description

set cmake  based CPP11 check instead the manual DGtal check
(see https://github.com/DGtal-team/DGtal/pull/1446)

# Checklist

- [ ] Doxygen documentation of the code completed (classes, methods, types, members...).
- [ ] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [ ] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [ ] Update the readme with potentially a screenshot of the tools if it applies. 
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
