### PR TITLE
fix warning ld boost prog options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,9 @@ if ( Boost_FOUND )
      ${Boost_PROGRAM_OPTIONS_LIBRARY} Boost::program_options)
    SET(DGtalLibInc ${Boost_INCLUDE_DIRS})
    ## Used to avoid ld warnings
-   set (CMAKE_CXX_FLAGS "-fvisibility=hidden")
+   if(APPLE)
+      set (CMAKE_CXX_FLAGS "-fvisibility=hidden")
+   endif(APPLE)
 endif( Boost_FOUND )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,8 @@ if ( Boost_FOUND )
      ${Boost_LIBRAIRIES}
      ${Boost_PROGRAM_OPTIONS_LIBRARY} Boost::program_options)
    SET(DGtalLibInc ${Boost_INCLUDE_DIRS})
+   ## Used to avoid ld warnings
+   set (CMAKE_CXX_FLAGS "-fvisibility=hidden")
 endif( Boost_FOUND )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ if ( Boost_FOUND )
      ${Boost_LIBRAIRIES}
      ${Boost_PROGRAM_OPTIONS_LIBRARY} Boost::program_options)
    SET(DGtalLibInc ${Boost_INCLUDE_DIRS})
-   ## Used to avoid ld warnings
+   ## Used to avoid ld warnings (to be removed when using CLI11 instead program_options)
    if(APPLE)
       set (CMAKE_CXX_FLAGS "-fvisibility=hidden")
    endif(APPLE)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@
   - set cmake  based CPP11 check instead the manual DGtal check. (Bertrand
     Kerautret [#364](https://github.com/DGtal-team/DGtalTools/pull/364))
   - fix ld boost program options macos warnings.
-    Kerautret [#XXX](https://github.com/DGtal-team/DGtalTools/pull/XXX))
+    Kerautret [#366](https://github.com/DGtal-team/DGtalTools/pull/366))
     
 - *volumetric:
   - Passing argument by const reference in (min|max|mean)Val of volSubSample.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,12 +5,15 @@
     [#356](https://github.com/DGtal-team/DGtalTools/pull/356))
   - set cmake  based CPP11 check instead the manual DGtal check. (Bertrand
     Kerautret [#364](https://github.com/DGtal-team/DGtalTools/pull/364))
-
+  - fix ld boost program options macos warnings.
+    Kerautret [#XXX](https://github.com/DGtal-team/DGtalTools/pull/XXX))
+    
 - *volumetric:
   - Passing argument by const reference in (min|max|mean)Val of volSubSample.
     (Roland Denis, [#359](https://github.com/DGtal-team/DGtalTools/pull/359/files))
   - Using SourceForge to download doxygen sources during Travis CI jobs.
     (Roland Denis [#360](https://github.com/DGtal-team/DGtalTools/pull/360))
+
 
 # DGtalTools 1.0
 


### PR DESCRIPTION
# PR Description
small PR related to the ld boost prog options warnings like:

ld: warning: direct access in function 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::program_options::validation_error> >::rethrow() const' from file '/usr/local/lib/libboost_program_options.a(value_semantic.o)' to global weak symbol 'typeinfo for boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::program_options::validation_error> >' from file 'CMakeFiles/shapeGenerator.dir/shapeGenerator.cpp.o' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.



# Checklist

- [x] Doxygen documentation of the code completed (classes, methods, types, members...).
- [x] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [x] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
