### PR TITLE
Iktvol with double input image and new option

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,12 @@
   - Using SourceForge to download doxygen sources during Travis CI jobs.
     (Roland Denis [#360](https://github.com/DGtal-team/DGtalTools/pull/360))
 
+- *converters*
+  - itk2vol: change type of threshold parameter in order to be able to
+    convert ITK images of type double.  (Bertrand Kerautret, -
+    [#367](https://github.com/DGtal-team/DGtalTools/pull/367))
+
+
 # DGtalTools 1.0
 
 - *generators*

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,7 +14,8 @@
 
 - *converters*
   - itk2vol: change type of threshold parameter in order to be able to
-    convert ITK images of type double.  (Bertrand Kerautret, -
+    convert ITK images of type double, it also adds a new option to mask the
+    source image using another image.  (Bertrand Kerautret, -
     [#367](https://github.com/DGtal-team/DGtalTools/pull/367))
 
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,7 +23,7 @@
     
 
 - *converters*
-  - itk2vol: change type of threshold parameter in order to be able to
+  - itk2vol: change the type of the threshold parameter in order to be able to
     convert ITK images of type double, it also adds a new option to mask the
     source image using another image.  (Bertrand Kerautret, -
     [#367](https://github.com/DGtal-team/DGtalTools/pull/367))

--- a/converters/itk2vol.cpp
+++ b/converters/itk2vol.cpp
@@ -75,7 +75,7 @@ namespace po = boost::program_options;
 int main( int argc, char** argv )
 {
   typedef ImageContainerBySTLVector < Z3i::Domain, unsigned char > Image3DChar;
-  typedef ImageContainerBySTLVector < Z3i::Domain,  int > Image3D;
+  typedef ImageContainerBySTLVector < Z3i::Domain,  double > Image3D;
   
   // parse command line ----------------------------------------------
   po::options_description general_opt("Allowed options are ");
@@ -83,8 +83,8 @@ int main( int argc, char** argv )
     ("help,h", "display this message")
     ("input,i", po::value<std::string>(), "Any file format in the ITK library (mhd, mha, ...) " )
     ("output,o", po::value<std::string>(), "volumetric file (.vol, .pgm3d) " )
-    ("inputMin", po::value<int>()->default_value(-1000), "set minimum density threshold on Hounsfield scale")
-    ("inputMax", po::value<int>()->default_value(3000), "set maximum density threshold on Hounsfield scale");
+    ("inputMin", po::value<double>()->default_value(-1000.0), "set minimum density threshold on Hounsfield scale")
+    ("inputMax", po::value<double>()->default_value(3000.0), "set maximum density threshold on Hounsfield scale");
 
   
   
@@ -116,9 +116,9 @@ int main( int argc, char** argv )
   
   string inputFilename = vm["input"].as<std::string>();
   string outputFilename = vm["output"].as<std::string>();
-  int inputMin = vm["inputMin"].as<int>();
-  int inputMax = vm["inputMax"].as<int>();
-  typedef DGtal::functors::Rescaling<int ,unsigned char > RescalFCT;
+  double inputMin = vm["inputMin"].as<double>();
+  double inputMax = vm["inputMax"].as<double>();
+  typedef DGtal::functors::Rescaling<double ,unsigned char > RescalFCT;
   
   trace.info() << "Reading input input file " << inputFilename ; 
   Image3D inputImage = ITKReader< Image3D  >::importITK(inputFilename);

--- a/converters/itk2vol.cpp
+++ b/converters/itk2vol.cpp
@@ -52,11 +52,22 @@ using namespace DGtal;
 @b Allowed @b options @b are:
 
 @code
-  -h [ --help ]           display this message
-  -i [ --input ] arg      Any file format in the ITK library (mhd, mha, ...) 
-  -o [ --output ] arg     volumetric file (.vol, .pgm3d) 
-  --inputMin arg (=-1000) set minimum density threshold on Hounsfield scale
-  --inputMax arg (=3000)  set maximum density threshold on Hounsfield scale
+ -h [ --help ]                     display this message
+  -i [ --input ] arg                Any file format in the ITK library (mhd, 
+                                    mha, ...) 
+  -o [ --output ] arg               volumetric file (.vol, .pgm3d) 
+  -m [ --maskImage ] arg            Use a mask image to remove image part 
+                                    (where mask is 0). The default mask value 
+                                    can be changed using mask default value.
+  -r [ --maskRemoveLabel ] arg (=0) Change the label value that define the part
+                                    of the image to be removed by the option 
+                                    --maskImage.
+  -t [ --inputType ] arg (=int)     to sepcify the input image type (int or 
+                                    double).
+  --inputMin arg (=-1000)           set minimum density threshold on Hounsfield
+                                    scale
+  --inputMax arg (=3000)            set maximum density threshold on Hounsfield
+                                    scale
 @endcode
 
 @b Example:
@@ -102,7 +113,7 @@ int main( int argc, char** argv )
     ("input,i", po::value<std::string>(), "Any file format in the ITK library (mhd, mha, ...) " )
     ("output,o", po::value<std::string>(), "volumetric file (.vol, .pgm3d) " )
     ("maskImage,m", po::value<std::string>(), "Use a mask image to remove image part (where mask is 0). The default mask value can be changed using mask default value." )
-    ("maskRemoveLabel,r", po::value<int>()->default_value(0), "Change the label value that define the part of the image to be removed by the option --maskImage." )
+    ("maskRemoveLabel,r", po::value<int>()->default_value(0), "Change the label value that defines the part of input image to be removed by the option --maskImage." )
     ("inputType,t", po::value<std::string>()->default_value("int"), "to sepcify the input image type (int or double)." )
     ("inputMin", po::value<double>()->default_value(-1000.0), "set minimum density threshold on Hounsfield scale")
     ("inputMax", po::value<double>()->default_value(3000.0), "set maximum density threshold on Hounsfield scale");

--- a/converters/itk2vol.cpp
+++ b/converters/itk2vol.cpp
@@ -59,7 +59,7 @@ using namespace DGtal;
   -m [ --maskImage ] arg            Use a mask image to remove image part 
                                     (where mask is 0). The default mask value 
                                     can be changed using mask default value.
-  -r [ --maskRemoveLabel ] arg (=0) Change the label value that define the part
+  -r [ --maskRemoveLabel ] arg (=0) Change the label value that defines the part
                                     of the image to be removed by the option 
                                     --maskImage.
   -t [ --inputType ] arg (=int)     to sepcify the input image type (int or 
@@ -203,5 +203,4 @@ int main( int argc, char** argv )
   return 0;
   
 }
-
 

--- a/volumetric/3dVolMarchingCubes.cpp
+++ b/volumetric/3dVolMarchingCubes.cpp
@@ -120,7 +120,7 @@ int main( int argc, char** argv )
   general_opt.add_options()
   ("help,h", "display this message")
   ("input,i", po::value<std::string>(), "the volume file (.vol)" )
-  ("threshold,t",  po::value<unsigned int>()->default_value(1), "the value that defines the isosurface in the image (an integer between 0 and 255)." )
+  ("threshold,t",  po::value<double>()->default_value(1.0), "the value that defines the isosurface in the image (an integer between 0 and 255)." )
   ("adjacency,a",  po::value<unsigned int>()->default_value(0), "0: interior adjacency, 1: exterior adjacency")
   ("output,o",  po::value<std::string>()->default_value( "marching-cubes.off" ), "the output OFF file that represents the geometry of the isosurface")
   ("noise,n",  po::value<double>(), "Kanungo noise level in ]0,1[. Note that only the largest connected component is considered and that no specific embedder is used.");
@@ -149,7 +149,7 @@ int main( int argc, char** argv )
     return 1;
   }
   std::string inputFilename = vm["input"].as<std::string>();
-  unsigned int threshold = vm["threshold"].as<unsigned int>();
+  double threshold = vm["threshold"].as<double>();
   bool intAdjacency = ( vm["adjacency"].as<unsigned int>() == 0 );
   std::string outputFilename = vm["output"].as<std::string>();
   double noise ;


### PR DESCRIPTION
# PR Description
Sometime the ITK images can be of type double, a new option is added  to consider ITK image as double. This PR also add an useful option to mask the source image.

# Checklist

- [x] Doxygen documentation of the code completed (classes, methods, types, members...).
- [x] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [x] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
