### PR TITLE
fix IO bug in 3dVolMarchingCubes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,9 @@
     (Roland Denis, [#359](https://github.com/DGtal-team/DGtalTools/pull/359/files))
   - Using SourceForge to download doxygen sources during Travis CI jobs.
     (Roland Denis [#360](https://github.com/DGtal-team/DGtalTools/pull/360))
+  - Fix a wrong error message that appears when using the tool (wrong IO error)
+    (Bertrand Kerautret
+    [#368](https://github.com/DGtal-team/DGtalTools/pull/368))
 
 # DGtalTools 1.0
 

--- a/volumetric/3dVolMarchingCubes.cpp
+++ b/volumetric/3dVolMarchingCubes.cpp
@@ -270,6 +270,7 @@ int main( int argc, char** argv )
     
     if ( out.good() )
       digSurf.exportEmbeddedSurfaceAs3DOFF( out, cellEmbedder );
+    else
     {
       trace.error()<<"IO error while opening the output file"<<std::endl;
       exit(2);


### PR DESCRIPTION
# PR Description
Fix IO error message that wrongly appears in 3dVolMarchingCubes after writing result file.

# Checklist

- [x] Doxygen documentation of the code completed (classes, methods, types, members...).
- [x] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [x] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
