### PR TITLE
volBoundary2obj using Shortcut

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,11 +6,16 @@
   - set cmake  based CPP11 check instead the manual DGtal check. (Bertrand
     Kerautret [#364](https://github.com/DGtal-team/DGtalTools/pull/364))
 
-- *volumetric:
+- *volumetric*
   - Passing argument by const reference in (min|max|mean)Val of volSubSample.
     (Roland Denis, [#359](https://github.com/DGtal-team/DGtalTools/pull/359/files))
   - Using SourceForge to download doxygen sources during Travis CI jobs.
     (Roland Denis [#360](https://github.com/DGtal-team/DGtalTools/pull/360))
+
+- *converters*
+  - 3dVolMarchingCubes improved using new Shortcuts helpers.
+    (Bertrand Kerautret
+    [#370](https://github.com/DGtal-team/DGtalTools/pull/370))
 
 # DGtalTools 1.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,7 +14,7 @@
 
 - *converters*
   - volBoundary2obj improved using new Shortcuts helpers.
-    (Bertrand Kerautret
+    (Bertrand Kerautret 
     [#370](https://github.com/DGtal-team/DGtalTools/pull/370))
 
 # DGtalTools 1.0

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,7 +13,7 @@
     (Roland Denis [#360](https://github.com/DGtal-team/DGtalTools/pull/360))
 
 - *converters*
-  - 3dVolMarchingCubes improved using new Shortcuts helpers.
+  - volBoundary2obj improved using new Shortcuts helpers.
     (Bertrand Kerautret
     [#370](https://github.com/DGtal-team/DGtalTools/pull/370))
 

--- a/converters/volBoundary2obj.cpp
+++ b/converters/volBoundary2obj.cpp
@@ -208,12 +208,12 @@ int main( int argc, char** argv )
   if (vm.count("triangulatedSurface"))
   {
     auto tr = SH3::makeTriangulatedSurface(surface);
-    auto ok  = SH3::saveOBJ( tr, SH3::RealVectors(), SH3::Colors(), outputFilename, cD );
+    auto ok  = SH3::saveOBJ( tr, SH3::RealVectors(), SH3::Colors(), outputFilename, Color( 32, 32, 32 ), cD );
     return ok ? EXIT_SUCCESS : EXIT_FAILURE ;
   }
   else
   {
-    auto ok  = SH3::saveOBJ( surface, SH3::RealVectors(), SH3::Colors(), outputFilename,cD);
+    auto ok  = SH3::saveOBJ( surface, SH3::RealVectors(), SH3::Colors(), outputFilename, Color( 32, 32, 32 ), cD);
     return  ok ? EXIT_SUCCESS : EXIT_FAILURE;
   }
   return EXIT_SUCCESS;

--- a/converters/volBoundary2obj.cpp
+++ b/converters/volBoundary2obj.cpp
@@ -52,6 +52,9 @@
 #include "DGtal/io/Color.h"
 #include "DGtal/io/colormaps/GradientColorMap.h"
 
+#include "DGtal/helpers/StdDefs.h"
+#include "DGtal/helpers/Shortcuts.h"
+#include "DGtal/helpers/ShortcutsGeometry.h"
 
 using namespace std;
 using namespace DGtal;
@@ -61,74 +64,67 @@ using namespace DGtal;
 namespace po = boost::program_options;
 
 /**
-   @page volBoundary2obj volBoundary2obj
-   @brief  Extracts digital points from 3d vol files.
+ @page volBoundary2obj volBoundary2obj
+ @brief  Extracts digital points from 3d vol files.
+ 
+ @b Usage: volBoundary2obj [input] [output]
+ 
+ @b Allowed @b options @b are:
+ 
+ @code
+  -h [ --help ]                    display this message
+  -i [ --input ] arg               vol file (.vol, .longvol .p3d, .pgm3d and if
+                                   WITH_ITK is selected: dicom, dcm, mha, mhd).
+                                   For longvol, dicom, dcm, mha or mhd formats,
+                                   the input values are linearly scaled between
+                                   0 and 255.
+  -o [ --output ] arg              output obj file (.obj)
+  -m [ --thresholdMin ] arg (=0)   threshold min (excluded) to define binary 
+                                   shape
+  -M [ --thresholdMax ] arg (=255) threshold max (included) to define binary 
+                                   shape
+  --customDiffuse arg              set the R, G, B, A components of the diffuse
+                                   colors of the mesh faces.
+  --rescaleInputMin arg (=0)       min value used to rescale the input 
+                                   intensity (to avoid basic cast into 8  bits 
+                                   image).
+  --rescaleInputMax arg (=255)     max value used to rescale the input 
+                                   intensity (to avoid basic cast into 8 bits 
+                                   image).
+  -t [ --triangulatedSurface ]     save the dual triangulated surface instead 
+                                   instead the default digital surface.
 
-   @b Usage: volBoundary2obj [input] [output]
-
-   @b Allowed @b options @b are:
-
-   @code
-   -h [ --help ]                    display this message
-   -i [ --input ] arg               vol file (.vol, .longvol .p3d, .pgm3d and if
-                                    WITH_ITK is selected: dicom, dcm, mha, mhd).
-                                    For longvol, dicom, dcm, mha or mhd formats,
-                                    the input values are linearly scaled between
-                                    0 and 255.
-   -o [ --output ] arg              output obj file (.obj)
-   -m [ --thresholdMin ] arg (=0)   threshold min (excluded) to define binary 
-   shape
-   -M [ --thresholdMax ] arg (=255) threshold max (included) to define binary 
-   shape
-   --rescaleInputMin arg (=0)       min value used to rescale the input 
-                                    intensity (to avoid basic cast into 8  bits 
-                                    image).
-   --rescaleInputMax arg (=255)     max value used to rescale the input 
-                                    intensity (to avoid basic cast into 8 bits 
-                                    image).
-
-   --mode arg (=BDRY)               set mode for display: INNER: inner voxels,
-   OUTER: outer voxels, BDRY: surfels, CLOSURE:
-   surfels with linels and pointels.
-   -n [ --normalization ]           Normalization so that the geometry fits in 
-   [-1/2,1/2]^3
-   @endcode
-
-   @b Example:
-   @code 
-   $ volBoundary2obj -i $DGtal/examples/samples/lobster.vol -m 80 -o out.obj
-   @endcode
-
-   You should obtain such a visualization:
-   @image html resVolBoundary2obj.png "resulting visualisation."
-
-   @see
-   @ref volBoundary2obj.cpp
-
-*/
+ @endcode
+ 
+ @b Example:
+ @code
+ $ volBoundary2obj -i $DGtal/examples/samples/lobster.vol -m 80 -o out.obj
+ @endcode
+ 
+ You should obtain such a visualization:
+ @image html resVolBoundary2obj.png "resulting visualisation."
+ 
+ @see
+ @ref volBoundary2obj.cpp
+ 
+ */
 
 
 int main( int argc, char** argv )
 {
-  typedef SpaceND<3,int> Space;
-  typedef KhalimskySpaceND<3,int> KSpace;
-  typedef HyperRectDomain<Space> Domain;
-  typedef ImageSelector<Domain, unsigned char>::Type Image;
-  typedef SurfelAdjacency<KSpace::dimension> MySurfelAdjacency;
-
   // parse command line ----------------------------------------------
   po::options_description general_opt("Allowed options are: ");
   general_opt.add_options()
-    ("help,h", "display this message")
-    ("input,i", po::value<std::string>(), "vol file (.vol, .longvol .p3d, .pgm3d and if WITH_ITK is selected: dicom, dcm, mha, mhd). For longvol, dicom, dcm, mha or mhd formats, the input values are linearly scaled between 0 and 255." )
-    ("output,o", po::value<std::string>(), "output obj file (.obj)" )
-    ("thresholdMin,m",  po::value<int>()->default_value(0), "threshold min (excluded) to define binary shape" )
-    ("thresholdMax,M",  po::value<int>()->default_value(255), "threshold max (included) to define binary shape" )
-    ("rescaleInputMin", po::value<DGtal::int64_t>()->default_value(0), "min value used to rescale the input intensity (to avoid basic cast into 8  bits image).")
-    ("rescaleInputMax", po::value<DGtal::int64_t>()->default_value(255), "max value used to rescale the input intensity (to avoid basic cast into 8 bits image).")
-    ("mode",  po::value<std::string>()->default_value("BDRY"), "set mode for display: INNER: inner voxels, OUTER: outer voxels, BDRY: surfels (default), CLOSURE: surfels with linels and pointels.")
-    ("normalization,n", "Normalization so that the geometry fits in [-1/2,1/2]^3") ;
-
+  ("help,h", "display this message")
+  ("input,i", po::value<std::string>(), "vol file (.vol, .longvol .p3d, .pgm3d and if WITH_ITK is selected: dicom, dcm, mha, mhd). For longvol, dicom, dcm, mha or mhd formats, the input values are linearly scaled between 0 and 255." )
+  ("output,o", po::value<std::string>(), "output obj file (.obj)" )
+  ("thresholdMin,m",  po::value<int>()->default_value(0), "threshold min (excluded) to define binary shape" )
+  ("thresholdMax,M",  po::value<int>()->default_value(255), "threshold max (included) to define binary shape" )
+  ("customDiffuse",po::value<std::vector<unsigned int> >()->multitoken(), "set the R, G, B, A components of the diffuse colors of the mesh faces." )
+  ("rescaleInputMin", po::value<DGtal::int64_t>()->default_value(0), "min value used to rescale the input intensity (to avoid basic cast into 8  bits image).")
+  ("rescaleInputMax", po::value<DGtal::int64_t>()->default_value(255), "max value used to rescale the input intensity (to avoid basic cast into 8 bits image).")
+  ("triangulatedSurface,t","save the dual triangulated surface instead instead the default digital surface.");
+  
   bool parseOK=true;
   po::variables_map vm;
   try{
@@ -139,137 +135,86 @@ int main( int argc, char** argv )
   }
   po::notify(vm);
   if( !parseOK || vm.count("help")||argc<=1)
-    {
-      std::cout << "Usage: " << argv[0] << " -i [input] -o [output]\n"
-                << "Export the boundary of a volume file to OBJ format. The mode specifies if you wish to see surface elements (BDRY), the inner voxels (INNER) or the outer voxels (OUTER) that touch the boundary."<< endl
-                << general_opt << "\n";
-      return 0;
-    }
-
+  {
+    std::cout << "Usage: " << argv[0] << " -i [input] -o [output]\n"
+    << "Export the boundary of a volume file to OBJ format. By default the resulting mesh is defined from the surfles of the surface elements, a triangulated (dual)"<< endl
+    << general_opt << "\n";
+    return 0;
+  }
+  
   if(! vm.count("input"))
-    {
-      trace.error() << " The file name was defined" << endl;
-      return 0;
-    }
-
+  {
+    trace.error() << " The file name was defined" << endl;
+    return 0;
+  }
+  
   if(! vm.count("output"))
-    {
-      trace.error() << " The output filename was defined" << endl;
-      return 0;
-    }
-
+  {
+    trace.error() << " The output filename was defined" << endl;
+    return 0;
+  }
+  
+  
+  // Using standard 3D digital space.
+  typedef Shortcuts<Z3i::KSpace> SH3;
+  typedef ShortcutsGeometry<Z3i::KSpace> SHG3;
+  auto params = SH3::defaultParameters() | SHG3::defaultParameters();
+  
+  
+  
   string inputFilename = vm["input"].as<std::string>();
   int thresholdMin = vm["thresholdMin"].as<int>();
   int thresholdMax = vm["thresholdMax"].as<int>();
-  string mode = vm["mode"].as<string>();
-  bool normalization = false;
-  if  (vm.count("normalization"))
-    normalization = true;
   
   DGtal::int64_t rescaleInputMin = vm["rescaleInputMin"].as<DGtal::int64_t>();
   DGtal::int64_t rescaleInputMax = vm["rescaleInputMax"].as<DGtal::int64_t>();
-
+  
   trace.beginBlock( "Loading file.." );
+  auto gimage    = SH3::makeGrayScaleImage(inputFilename);
   typedef DGtal::functors::Rescaling<DGtal::int64_t ,unsigned char > RescalFCT;
-  Image image =  GenericReader< Image >::importWithValueFunctor( inputFilename,RescalFCT(rescaleInputMin,
-                                                                                         rescaleInputMax,
-                                                                                         0, 255) );  
-  trace.info() << "Image loaded: "<<image<< std::endl;
+  RescalFCT f (rescaleInputMin, rescaleInputMax,0, 255);
+  for (const auto &i: gimage->domain()) gimage->setValue(i, f((*gimage)(i)));
+  
+  
+  auto bimage = SH3::makeBinaryImage(gimage,params( "thresholdMin", rescaleInputMin ) |
+                                     params( "thresholdMax", rescaleInputMax ) );
+  
+  
+  trace.info() << "Image loaded: "<<gimage<< std::endl;
   trace.endBlock();
-
-  trace.beginBlock( "Construct the Khalimsky space from the image domain." );
-  Domain domain = image.domain();
-  KSpace ks;
-  bool space_ok = ks.init( domain.lowerBound(), domain.upperBound(), true );
-  if (!space_ok)
-    {
-      trace.error() << "Error in the Khamisky space construction."<<std::endl;
-      return 2;
-    }
-  trace.endBlock();
-
-  trace.beginBlock( "Wrapping a digital set around image. " );
-  typedef functors::IntervalForegroundPredicate<Image> ThresholdedImage;
-  ThresholdedImage thresholdedImage( image, thresholdMin, thresholdMax );
-  trace.endBlock();
-
-  trace.beginBlock( "Extracting boundary by scanning the space. " );
-  typedef KSpace::SurfelSet SurfelSet;
-  typedef SetOfSurfels< KSpace, SurfelSet > MySetOfSurfels;
-  typedef DigitalSurface< MySetOfSurfels > MyDigitalSurface;
-  MySurfelAdjacency surfAdj( true ); // interior in all directions.
-  MySetOfSurfels theSetOfSurfels( ks, surfAdj );
-  Surfaces<KSpace>::sMakeBoundary( theSetOfSurfels.surfelSet(),
-                                   ks, thresholdedImage,
-                                   domain.lowerBound(),
-                                   domain.upperBound() );
-  MyDigitalSurface digSurf( theSetOfSurfels );
-  trace.info() << "Digital surface has " << digSurf.size() << " surfels."
-               << std::endl;
-  trace.endBlock();
-
-  trace.beginBlock( "Exporting everything." );
-  Board3D<Space,KSpace> board(ks);
-
-  board << SetMode3D(  ks.unsigns( *digSurf.begin() ).className(), "Basic" );
-  board << SetMode3D(  (*digSurf.begin()).className(), "Basic" );
-
-  typedef MyDigitalSurface::ConstIterator ConstIterator;
-  if ( mode == "BDRY" )
-    for ( ConstIterator it = digSurf.begin(), itE = digSurf.end(); it != itE; ++it )
-    { 
-      //board << ks.unsigns( *it );
-      bool indirectFilled = thresholdedImage(ks.sCoords( ks.sIndirectIncident( *it, ks.sOrthDir( *it ) ) ));
-      bool directFilled = thresholdedImage(ks.sCoords( ks.sDirectIncident( *it, ks.sOrthDir( *it ) ) ));
-      Z3i::RealPoint sc = board.embedKS(*it);
-      Z3i::RealPoint n (0,0,0);
-      auto ip = ks.sCoords( ks.sIndirectIncident( *it, ks.sOrthDir( *it ) ) );  
-      if (!indirectFilled)
-      {
-        ip = ks.sCoords( ks.sDirectIncident( *it, ks.sOrthDir( *it ) ) );
-      }
-      n = sc - Z3i::RealPoint(static_cast<Z3i::RealPoint::Component>(ip[0]),
-                              static_cast<Z3i::RealPoint::Component>(ip[1]),
-                              static_cast<Z3i::RealPoint::Component>(ip[2]));
-      bool xodd = ks.sIsOpen( *it, 0 );
-      bool yodd = ks.sIsOpen( *it, 1 );
-      bool zodd = ks.sIsOpen( *it, 2 );      
-      board.addQuadFromSurfelCenterWithNormal
-        ( Z3i::RealPoint( sc[0]+(xodd? 0:0.5 ), sc[1]+(yodd? 0:0.5 ), sc[2]+(zodd? 0:0.5 ) ),
-          ! xodd, ! yodd, ! zodd, n, true,  true, false );
-    }
-  else if ( mode == "INNER" )
-    for ( ConstIterator it = digSurf.begin(), itE = digSurf.end(); it != itE; ++it )
-      board << ks.sCoords( ks.sDirectIncident( *it, ks.sOrthDir( *it ) ) );
-  else if ( mode == "OUTER" )
-    for ( ConstIterator it = digSurf.begin(), itE = digSurf.end(); it != itE; ++it )
-      board << ks.sCoords( ks.sIndirectIncident( *it, ks.sOrthDir( *it ) ) );
-  else  if (mode == "CLOSURE")
-  {
-    std::set<KSpace::Cell> container;
-      for ( ConstIterator it = digSurf.begin(), itE = digSurf.end(); it != itE; ++it )
-        {
-          container.insert( ks.unsigns( *it ) );
-          KSpace::SCells oneNeig = ks.sLowerIncident(*it);
-          //Processing linels
-          for(KSpace::SCells::ConstIterator itt = oneNeig.begin(), ittend = oneNeig.end(); itt != ittend; ++itt)
-            {
-              container.insert( ks.unsigns( *itt) );
-              KSpace::SCells oneNeig2 = ks.sLowerIncident(*itt);
-              //Processing pointels
-              for(KSpace::SCells::ConstIterator ittt = oneNeig2.begin(), itttend = oneNeig2.end(); ittt != itttend; ++ittt)
-                container.insert( ks.unsigns(*ittt) );
-            }
-        }
-      trace.info()<< "Exporting "<< container.size() << " cells"<<std::endl;
-      for(auto cell: container)
-        board << cell;
-    }
-    
+  params( "faceSubdivision", "Centroid" )( "surfelAdjacency", 1);
+  
+  auto K         = SH3::getKSpace( bimage);
+  
+  
   string outputFilename = vm["output"].as<std::string>();
-
-  board.saveOBJ(outputFilename, normalization);
-  trace.endBlock();
-
+  bool customDiffuse =  vm.count("customDiffuse");
+  
+  SH3::Color cD ( 30,30,30 );
+  
+  if(customDiffuse)
+  {
+    std::vector<unsigned int > vectCol = vm["customDiffuse"].as<std::vector<unsigned int> >();
+    if(vectCol.size()!=4)
+    {
+      trace.error() << "colors specification should contain R,G,B and Alpha values"<< std::endl;
+    }
+    cD.setRGBi(vectCol[0], vectCol[1], vectCol[2], vectCol[3]);
+  }
+  
+  auto surface = SH3::makeLightDigitalSurface( bimage, K, params( "thresholdMin", thresholdMin ) |
+  params( "thresholdMax", thresholdMax ) );
+  
+  if (vm.count("triangulatedSurface"))
+  {
+    auto tr = SH3::makeTriangulatedSurface(surface);
+    auto ok  = SH3::saveOBJ( tr, SH3::RealVectors(), SH3::Colors(), outputFilename, cD );
+    return ok;
+  }
+  else
+  {
+    auto ok  = SH3::saveOBJ( surface, SH3::RealVectors(), SH3::Colors(), outputFilename,cD);
+    return ok;
+  }
   return 0;
 }

--- a/converters/volBoundary2obj.cpp
+++ b/converters/volBoundary2obj.cpp
@@ -209,12 +209,12 @@ int main( int argc, char** argv )
   {
     auto tr = SH3::makeTriangulatedSurface(surface);
     auto ok  = SH3::saveOBJ( tr, SH3::RealVectors(), SH3::Colors(), outputFilename, cD );
-    return ok;
+    return ok ? EXIT_SUCCESS : EXIT_FAILURE ;
   }
   else
   {
     auto ok  = SH3::saveOBJ( surface, SH3::RealVectors(), SH3::Colors(), outputFilename,cD);
-    return ok;
+    return  ok ? EXIT_SUCCESS : EXIT_FAILURE;
   }
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/converters/volBoundary2obj.cpp
+++ b/converters/volBoundary2obj.cpp
@@ -202,7 +202,7 @@ int main( int argc, char** argv )
     cD.setRGBi(vectCol[0], vectCol[1], vectCol[2], vectCol[3]);
   }
   
-  auto surface = SH3::makeLightDigitalSurface( bimage, K, params( "thresholdMin", thresholdMin ) |
+  auto surface = SH3::makeDigitalSurface( bimage, K, params( "thresholdMin", thresholdMin ) |
   params( "thresholdMax", thresholdMax ) );
   
   if (vm.count("triangulatedSurface"))

--- a/converters/volBoundary2obj.cpp
+++ b/converters/volBoundary2obj.cpp
@@ -19,6 +19,7 @@
  * @author Jacques-Olivier Lachaud (\c jacques-olivier.lachaud@univ-savoie.fr )
  * Laboratory of Mathematics (CNRS, UMR 5127), University of Savoie, France
  * @author David Coeurjolly (\c david.coeurjolly@liris.cnrs.fr )
+ * @author Bertrand Kerautret (\c bertrand.kerautret@liris.cnrs.fr )
  *
  * @date 2013/11/15
  *
@@ -166,18 +167,20 @@ int main( int argc, char** argv )
   int thresholdMin = vm["thresholdMin"].as<int>();
   int thresholdMax = vm["thresholdMax"].as<int>();
   
-  DGtal::int64_t rescaleInputMin = vm["rescaleInputMin"].as<DGtal::int64_t>();
-  DGtal::int64_t rescaleInputMax = vm["rescaleInputMax"].as<DGtal::int64_t>();
   
   trace.beginBlock( "Loading file.." );
-  auto gimage    = SH3::makeGrayScaleImage(inputFilename);
   typedef DGtal::functors::Rescaling<DGtal::int64_t ,unsigned char > RescalFCT;
+  DGtal::int64_t rescaleInputMin = vm["rescaleInputMin"].as<DGtal::int64_t>();
+  DGtal::int64_t rescaleInputMax = vm["rescaleInputMax"].as<DGtal::int64_t>();
   RescalFCT f (rescaleInputMin, rescaleInputMax,0, 255);
-  for (const auto &i: gimage->domain()) gimage->setValue(i, f((*gimage)(i)));
+
   
+  SH3::GrayScaleImage image =
+  GenericReader< SH3::GrayScaleImage >::importWithValueFunctor(inputFilename, f );
   
-  auto bimage = SH3::makeBinaryImage(gimage,params( "thresholdMin", rescaleInputMin ) |
-                                     params( "thresholdMax", rescaleInputMax ) );
+  auto gimage = CountedPtr<SH3::GrayScaleImage>( new SH3::GrayScaleImage( image ) );
+  auto bimage = SH3::makeBinaryImage(gimage,params( "thresholdMin", thresholdMin )
+                                                  ( "thresholdMax", thresholdMax ) );
   
   
   trace.info() << "Image loaded: "<<gimage<< std::endl;
@@ -190,7 +193,7 @@ int main( int argc, char** argv )
   string outputFilename = vm["output"].as<std::string>();
   bool customDiffuse =  vm.count("customDiffuse");
   
-  SH3::Color cD ( 30,30,30 );
+  SH3::Color cD ( 230,230,230 );
   
   if(customDiffuse)
   {
@@ -202,8 +205,7 @@ int main( int argc, char** argv )
     cD.setRGBi(vectCol[0], vectCol[1], vectCol[2], vectCol[3]);
   }
   
-  auto surface = SH3::makeDigitalSurface( bimage, K, params( "thresholdMin", thresholdMin ) |
-  params( "thresholdMax", thresholdMax ) );
+  auto surface = SH3::makeDigitalSurface( bimage, K );
   const std::string extension = outputFilename.substr( outputFilename.find_last_of(".") + 1 );  
   if (extension != "obj" && extension != "off")
   {

--- a/converters/volBoundary2obj.cpp
+++ b/converters/volBoundary2obj.cpp
@@ -138,7 +138,7 @@ int main( int argc, char** argv )
   if( !parseOK || vm.count("help")||argc<=1)
   {
     std::cout << "Usage: " << argv[0] << " -i [input] -o [output]\n"
-    << "Export the boundary of a volume file to OBJ format. By default the resulting mesh is defined from the surfles of the surface elements, a triangulated (dual)"<< endl
+    << "Export the boundary of a volume file to OBJ format. By default the resulting mesh is defined from the surfels of the surface elements, a triangulated (dual)"<< endl
     << general_opt << "\n";
     return 0;
   }

--- a/converters/volBoundary2obj.cpp
+++ b/converters/volBoundary2obj.cpp
@@ -117,7 +117,7 @@ int main( int argc, char** argv )
   general_opt.add_options()
   ("help,h", "display this message")
   ("input,i", po::value<std::string>(), "vol file (.vol, .longvol .p3d, .pgm3d and if WITH_ITK is selected: dicom, dcm, mha, mhd). For longvol, dicom, dcm, mha or mhd formats, the input values are linearly scaled between 0 and 255." )
-  ("output,o", po::value<std::string>(), "output obj file (.obj)" )
+  ("output,o", po::value<std::string>(), "output file (.obj or .off)." )
   ("thresholdMin,m",  po::value<int>()->default_value(0), "threshold min (excluded) to define binary shape" )
   ("thresholdMax,M",  po::value<int>()->default_value(255), "threshold max (included) to define binary shape" )
   ("customDiffuse",po::value<std::vector<unsigned int> >()->multitoken(), "set the R, G, B, A components of the diffuse colors of the mesh faces." )
@@ -204,17 +204,38 @@ int main( int argc, char** argv )
   
   auto surface = SH3::makeDigitalSurface( bimage, K, params( "thresholdMin", thresholdMin ) |
   params( "thresholdMax", thresholdMax ) );
-  
+  const std::string extension = outputFilename.substr( outputFilename.find_last_of(".") + 1 );  
+  if (extension != "obj" && extension != "off")
+  {
+    trace.warning() << "File extension not recognized, saving by default in objg format"<< std::endl;
+  }
   if (vm.count("triangulatedSurface"))
   {
     auto tr = SH3::makeTriangulatedSurface(surface);
-    auto ok  = SH3::saveOBJ( tr, SH3::RealVectors(), SH3::Colors(), outputFilename, Color( 32, 32, 32 ), cD );
+    bool ok = true;
+    if (extension!="off")
+    {
+      ok  = SH3::saveOBJ( tr, SH3::RealVectors(), SH3::Colors(), outputFilename, Color( 32, 32, 32 ), cD );
+    }
+    else 
+    {
+      ok  = SH3::saveOFF( tr, outputFilename, cD);
+    }
     return ok ? EXIT_SUCCESS : EXIT_FAILURE ;
   }
   else
   {
-    auto ok  = SH3::saveOBJ( surface, SH3::RealVectors(), SH3::Colors(), outputFilename, Color( 32, 32, 32 ), cD);
+    bool ok = true;
+    if (extension!="off")
+    {
+      ok  = SH3::saveOBJ( surface, SH3::RealVectors(), SH3::Colors(), outputFilename, Color( 32, 32, 32 ), cD);
+    } else
+    {
+      ok  = SH3::saveOFF( surface, outputFilename, cD);
+    }
     return  ok ? EXIT_SUCCESS : EXIT_FAILURE;
   }
   return EXIT_SUCCESS;
 }
+
+


### PR DESCRIPTION
# PR Description

volBoundary2obj improved using new Shortcuts helpers.
Note that it needs first merge of DGTal PR: [#1476](https://github.com/DGtal-team/DGtal/pull/1476)

# Checklist

- [x] Doxygen documentation of the code completed (classes, methods, types, members...).
- [x] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [x] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
