### PR TITLE
Fix doc url

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,10 @@
   - Using SourceForge to download doxygen sources during Travis CI jobs.
     (Roland Denis [#360](https://github.com/DGtal-team/DGtalTools/pull/360))
 
+- *documentations*
+  -  Fix doc link to the DGtal lib in the tool source (from new github website).
+     Kerautret [#371](https://github.com/DGtal-team/DGtalTools/pull/371))
+    
 # DGtalTools 1.0
 
 - *generators*

--- a/doc/doxy.config.in
+++ b/doc/doxy.config.in
@@ -2076,8 +2076,8 @@ SKIP_FUNCTION_MACROS   = YES
 # the path). If a tag file is not located in the directory in which doxygen is
 # run, you must also specify the path to the tagfile here.
 
-TAGFILES               = "DGtal-tagfile=http://dgtal.org/doc/nightly/" \
-                         "Board-tagfile=http://dgtal.org/doc/nightly/"
+TAGFILES               = "DGtal-tagfile=https://dgtal-team.github.io/doc-nightly/" \
+                         "Board-tagfile=https://dgtal-team.github.io/doc-nightly/"
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create a
 # tag file that is based on the input files it reads. See section "Linking to


### PR DESCRIPTION
# PR Description
Fix link to DGTal not working with new url 
![Capture d’écran 2020-04-16 à 22 45 01](https://user-images.githubusercontent.com/772865/79508854-a0a75200-803a-11ea-90a3-a7a939cd7fae.png)

![Capture d’écran 2020-04-16 à 22 45 37](https://user-images.githubusercontent.com/772865/79508824-91280900-803a-11ea-935b-ec90357117b4.png)

# Checklist

- [x] Doxygen documentation of the code completed (classes, methods, types, members...).
- [x] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [x] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
