### PR TITLE
Fix travis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: cpp
 dist: xenial
+osx_image: xcode12.2
 
 os:
 - linux
 - osx
+
+
 compiler:
 - gcc
 - clang

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,24 +66,6 @@ SET(VERSION ${DGtalTools_VERSION_MAJOR}.${DGtalTools_VERSION_MINOR}.${DGtalTools
 
 
 
- # -----------------------------------------------------------------------------
- # Looking for boost
- # -----------------------------------------------------------------------------
-
-set(Boost_USE_STATIC_LIBS   ON)
-set(Boost_USE_MULTITHREADED ON)
-set(Boost_USE_STATIC_RUNTIME OFF)
-set(Boost_FOUND FALSE)
-FIND_PACKAGE(Boost 1.50.0 REQUIRED)
-if ( Boost_FOUND )
-  ADD_DEFINITIONS(${BOOST_DEFINITIONS} -DBOOST_ALL_NO_LIB)
-  # SYSTEM to avoid warnings from boost.
-  include_directories(SYSTEM ${Boost_INCLUDE_DIRS} )
-  SET(DGtalToolsLibDependencies ${DGtalToolsLibDependencies}
-     ${Boost_LIBRAIRIES})
-   SET(DGtalLibInc ${Boost_INCLUDE_DIRS})
-endif( Boost_FOUND )
-
 
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@
 PROJECT(DGtalTools)
 
 cmake_minimum_required (VERSION 3.1)
+cmake_policy(SET CMP0057 NEW)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,9 @@
 # DGtalTools 1.2
+- *global*
 
-
+  - Travis: Fix old default osx_image with xcode12.2 and remove non used boost
+    cmake references. (Bertrand Kerautret [#394](https://github.com/DGtal-team/DGtalTools/pull/394)) 
+    
 
 # DGtalTools 1.1
 


### PR DESCRIPTION
# PR Description
 Fix old default osx_image with xcode12.2 and remove non used boost  cmake references.

# Checklist
- [x] Doxygen documentation of the code completed (classes, methods, types, members...).
- [x] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [x] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
