### PR TITLE
Cmake policy setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ cmake_minimum_required (VERSION 3.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 
+cmake_policy(SET CMP0048 OLD) # project() doesn't have VERSION
 
 # -----------------------------------------------------------------------------
 # DGtal dependencies


### PR DESCRIPTION
Error in cmake command : "Policy CMP0057 is not set"

*Thanks a lot for contributing to DGtalTools, before submitting your PR, please fill up the description and make sure that all checkboxes are checked.*

# PR Description

*your description here*

# Checklist

- [ ] Doxygen documentation of the code completed (classes, methods, types, members...).
- [ ] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [ ] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [ ] Update the readme with potentially a screenshot of the tools if it applies. 
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
