### PR TITLE
exporting image spacing in volReSample

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,12 +5,18 @@
   - Travis: Fix old default osx_image with xcode12.2 and remove non used boost
     cmake references. (Bertrand Kerautret [#394](https://github.com/DGtal-team/DGtalTools/pull/394)) 
 
-- *visualisation*:
+- *visualisation*
   - 3dVolViewer: improvement of the possibility to read input image of type double (with ITK).
     New possibility to select the voxel in order to display image intensity.    
     (Bertrand Kerautret [#402](https://github.com/DGtal-team/DGtalTools/pull/402))
   - 3dVolBoundaryViewer: fix compilation issue (related to CLI11 change) when ITK is activated.
     (Bertrand Kerautret [#395](https://github.com/DGtal-team/DGtalTools/pull/395))
+
+- *volumetric*
+  - volReSample: it can now export image including ITK image spacing.
+    (Bertrand Kerautret [#404](https://github.com/DGtal-team/DGtalTools/pull/404))
+  
+
 
 
 # DGtalTools 1.1


### PR DESCRIPTION
# PR Description
Thanks to the recent TP including image spacing export, it can now export image including image spacing.


# Checklist

- [x] Doxygen documentation of the code completed (classes, methods, types, members...).
- [x] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [x] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
