### PR TITLE
new option to interpret intensity as transparency

### DIFF
--- a/.github/workflows/buildAndDocumentation.yml
+++ b/.github/workflows/buildAndDocumentation.yml
@@ -1,6 +1,10 @@
 name: CI (linux/macOS)
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,7 +20,7 @@
   - Uniform input/output option with previous use of CLI11 (issue #405).
     (Bertrand Kerautret [#406](https://github.com/DGtal-team/DGtalTools/pull/406)) 
   - Comply with cmake Policy CMP0115 "Source file extensions must be
-     explicit". (Bertrand Kerautret and David Coeurjolly, [#407](https://github.com/DGtal-team/DGtal/pull/407))
+     explicit". (Bertrand Kerautret and David Coeurjolly, [#407](https://github.com/DGtal-team/DGtalTools/pull/407))
 
 - *visualisation*
   - 3dVolViewer: improvement of the possibility to read input image of type double (with ITK).


### PR DESCRIPTION
# PR Description
All in title..

# Checklist

- [ ] Doxygen documentation of the code completed (classes, methods, types, members...).
- [ ] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [ ] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [ ] Update the readme with potentially a screenshot of the tools if it applies. 
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Github Actions & appveyor).
