### PR TITLE
bug VTKIMAGEDATA_CONTAINER_I in volAddBorder

### DIFF
--- a/volumetric/criticalKernelsThinning3D.cpp
+++ b/volumetric/criticalKernelsThinning3D.cpp
@@ -166,7 +166,7 @@ int main(int argc, char* const argv[]){
   }
   trace.beginBlock("Reading input");
   using Domain = Z3i::Domain ;
-  using Image = ImageSelector < Z3i::Domain, unsigned char, ITKIMAGEDATA_CONTAINER_I>::Type ;
+  using Image = ImageSelector < Z3i::Domain, unsigned char, VTKIMAGEDATA_CONTAINER_I>::Type ;
   
   Image image = GenericReader<Image>::import(inputFileName);
   trace.endBlock();


### PR DESCRIPTION
*Thanks a lot for contributing to DGtalTools, before submitting your PR, please fill up the description and make sure that all checkboxes are checked.*

# PR Description : bug VTKIMAGEDATA_CONTAINER_I in volAddBorder

*I found bug VTKIMAGEDATA_CONTAINER_I in volAddBorder*

# Checklist

- [x] Doxygen documentation of the code completed (classes, methods, types, members...).
- [x] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [x] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Github Actions & appveyor).
