### PR TITLE
Vol re sample exp fix

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,8 @@
 # DGtalTools 1.4 (beta)
 
-
+- *volumetric*
+    - volReSample: fix the impossibility to export to vol when ITK is activated
+      (Bertrand Kerautret [#445](https://github.com/DGtal-team/DGtalTools/pull/445))
 
 # DGtalTools 1.3
 

--- a/volumetric/volReSample.cpp
+++ b/volumetric/volReSample.cpp
@@ -135,13 +135,22 @@ int main( int argc, char** argv )
   const functors::Identity aFunctor{};
   SamplerImageAdapter sampledImage ( input3dImage, reSampler.getSubSampledDomain(), reSampler, aFunctor );
 #ifdef WITH_ITK
-  ITKWriter<SamplerImageAdapter>::exportITK(outputFileName, sampledImage,
-                                            Z3i::RealPoint(aGridSizeReSample[0],
-                                                           aGridSizeReSample[1],
-                                                           aGridSizeReSample[2]));
+    const std::string ext = outputFileName.substr( outputFileName.find_last_of(".") + 1 );
+    if (std::find(ITK_IO_IMAGE_EXT.begin(),
+                  ITK_IO_IMAGE_EXT.end(), ext) != ITK_IO_IMAGE_EXT.end() )
+    {
+        ITKWriter<SamplerImageAdapter>::exportITK(outputFileName, sampledImage,
+                                                  Z3i::RealPoint(aGridSizeReSample[0],
+                                                                 aGridSizeReSample[1],
+                                                                 aGridSizeReSample[2]));
+    }
+    else
+    {
+        GenericWriter<SamplerImageAdapter>::exportFile(outputFileName, sampledImage);
+    }
+
 #else
   GenericWriter<SamplerImageAdapter>::exportFile(outputFileName, sampledImage);
-
 #endif
   
   return 0;


### PR DESCRIPTION
# PR Description
Small fix to export vol when ITK is activate (fix due to the use the use of special ITK grid space use) 

# Checklist

- [x] Doxygen documentation of the code completed (classes, methods, types, members...).
- [x] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [ ] Update the readme with potentially a screenshot of the tools if it applies. 
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Github Actions & appveyor).
