### PR TITLE
Mesh viewer edit

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # DGtalTools 1.4 (beta)
 
+- *visualisation*
+  - meshViewer: new option to change the default background color and some fix 
+    and simplications of the option --doSnapShotAndExit. 
+    (Bertrand Kerautret [#448](https://github.com/DGtal-team/DGtalTools/pull/448))
 
 
 # DGtalTools 1.3

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,9 +1,10 @@
 # DGtalTools 1.4 (beta)
 
 - *visualisation*
-  - meshViewer: new option to change the default background color and some fix 
-    and simplications of the option --doSnapShotAndExit. 
-    (Bertrand Kerautret [#448](https://github.com/DGtal-team/DGtalTools/pull/448))
+  - meshViewer: new options to change the default background color and
+    to load camera settings at startup. It also includes some fix and
+    simplications of the option --doSnapShotAndExit.  (Bertrand
+    Kerautret [#448](https://github.com/DGtal-team/DGtalTools/pull/448))
 
 
 # DGtalTools 1.3

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,12 +2,13 @@
 
 - *visualisation*
   - meshViewer: new options to change the default background color, to
-    load camera settings at startup and to change at startup the light
-    source mode attached or not to the camera. It includes a fix of
-    the -customColorMesh for obj mesh and add new possibilities to
-    custom the color of each mesh given as input. It also includes a
-    fix and some simplications of the option --doSnapShotAndExit.
-    (Bertrand Kerautret
+    load camera settings at startup, to change at startup the light
+    source mode attached or not to the camera and improve transparency
+    process at startup rendering. It includes a fix of the
+    -customColorMesh for obj mesh and add new possibilities to custom
+    the color of each mesh given as input. It also includes a fix and
+    some simplications of the option --doSnapShotAndExit.  (Bertrand
+    Kerautret
     [#448](https://github.com/DGtal-team/DGtalTools/pull/448))
 
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,10 +1,12 @@
 # DGtalTools 1.4 (beta)
 
 - *visualisation*
-  - meshViewer: new options to change the default background color and
-    to load camera settings at startup. It also includes some fix and
-    simplications of the option --doSnapShotAndExit.  (Bertrand
-    Kerautret [#448](https://github.com/DGtal-team/DGtalTools/pull/448))
+  - meshViewer: new options to change the default background color, to
+    load camera settings at startup and to change at startup the light
+    source mode attached or not to the camera. It also includes some
+    fix and simplications of the option --doSnapShotAndExit.
+    (Bertrand Kerautret
+    [#448](https://github.com/DGtal-team/DGtalTools/pull/448))
 
 
 # DGtalTools 1.3

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,8 +3,10 @@
 - *visualisation*
   - meshViewer: new options to change the default background color, to
     load camera settings at startup and to change at startup the light
-    source mode attached or not to the camera. It also includes some
-    fix and simplications of the option --doSnapShotAndExit.
+    source mode attached or not to the camera. It includes a fix of
+    the -customColorMesh for obj mesh and add new possibilities to
+    custom the color of each mesh given as input. It also includes a
+    fix and some simplications of the option --doSnapShotAndExit.
     (Bertrand Kerautret
     [#448](https://github.com/DGtal-team/DGtalTools/pull/448))
 

--- a/visualisation/3dVolViewer.cpp
+++ b/visualisation/3dVolViewer.cpp
@@ -77,7 +77,8 @@ using namespace Z3i;
    --colorMesh UINT ...                  set the color of Mesh (given from displayMesh option) : r g b a
    -d,--doSnapShotAndExit                save display snapshot into file. Notes that the camera setting is set by default according the last saved configuration (use SHIFT+Key_M to save current camera setting in the Viewer3D). If the camera setting was not saved it will use the default camera setting.
    -t,--transparency UINT=255            change the defaukt transparency
-   
+   --useLastCameraSetting                use the last camera setting of the user (i.e if a    .qglviewer.xml file is present in the current directory)
+
  
  @endcode
  
@@ -215,6 +216,7 @@ int main( int argc, char** argv )
   bool interactiveDisplayVoxCoords {false};
   bool transIntensity {false};
   bool transIntensitySq {false};
+  bool useLastCamSet {false};
 
   app.add_option("-i,--input,1", inputFileName, "vol file (.vol, .longvol .p3d, .pgm3d and if WITH_ITK is selected: dicom, dcm, mha, mhd). For longvol, dicom, dcm, mha or mhd formats, the input values are linearly scaled between 0 and 255." )
   ->required()
@@ -235,9 +237,9 @@ int main( int argc, char** argv )
   app.add_option("--transparency,-t", transparency, "change the defaukt transparency", true);
   app.add_flag("--transIntensity",transIntensity , "Used vocel intensity to define transparency valeue");
   app.add_flag("--transIntensitySq",transIntensitySq , "Used squared vocel intensity to define transparency valeue");
-
   app.add_flag("--interactiveDisplayVoxCoords,-c", interactiveDisplayVoxCoords, " by using this option the coordinates can be displayed after selection (shift+left click on voxel).");
-  app.get_formatter()->column_width(40);
+ app.add_flag("--useLastCameraSetting", useLastCamSet, "use the last camera setting of the user (i.e if a .qglviewer.xml file is present in the current directory)");
+    app.get_formatter()->column_width(40);
   CLI11_PARSE(app, argc, argv);
   // END parse command line using CLI ----------------------------------------------
   
@@ -344,5 +346,17 @@ int main( int argc, char** argv )
     rename(s.str().c_str(), snapShotFile.c_str());
     return 0;
   }
+    
+  if (useLastCamSet)
+  {
+        viewer.restoreStateFromFile();
+  }
+  // First display transparency improve
+  viewer.sortTriangleFromCamera();
+  viewer.sortQuadFromCamera();
+  viewer.sortSurfelFromCamera();
+  viewer.sortPolygonFromCamera();
+  viewer  << Viewer::updateDisplay;
+  trace.info() << "[display ready]"<< std::endl;
   return application.exec();
 }

--- a/visualisation/3dVolViewer.cpp
+++ b/visualisation/3dVolViewer.cpp
@@ -212,6 +212,8 @@ int main( int argc, char** argv )
   std::string displayMesh;
   std::string snapShotFile;
   std::vector<unsigned int> colorMesh;
+  std::vector<unsigned int > customBGColor;
+
   string inputType {""};
   bool interactiveDisplayVoxCoords {false};
   bool transIntensity {false};
@@ -233,7 +235,9 @@ int main( int argc, char** argv )
   app.add_option("--displayMesh", displayMesh, "display a Mesh given in OFF or OFS format.");
   app.add_option("--colorMesh", colorMesh, "set the color of Mesh (given from displayMesh option) : r g b a ")
    ->expected(4);
-  app.add_flag("--doSnapShotAndExit,-d",snapShotFile, "save display snapshot into file. Notes that the camera setting is set by default according the last saved configuration (use SHIFT+Key_M to save current camera setting in the Viewer3D). If the camera setting was not saved it will use the default camera setting." );
+    app.add_option("--doSnapShotAndExit,-d", snapShotFile, "save display snapshot into file. Notes that the camera setting is set by default according the last saved configuration (use SHIFT+Key_M to save current camera setting in the Viewer3D). If the camera setting was not saved it will use the default camera setting.");
+  app.add_option("--customBGColor,-b", customBGColor, "set the R, G, B, A components of the colors of  the sdp view")
+      ->expected(3);
   app.add_option("--transparency,-t", transparency, "change the defaukt transparency", true);
   app.add_flag("--transIntensity",transIntensity , "Used vocel intensity to define transparency valeue");
   app.add_flag("--transIntensitySq",transIntensitySq , "Used squared vocel intensity to define transparency valeue");
@@ -266,7 +270,14 @@ int main( int argc, char** argv )
   Image3D_D  imageD = Image3D_D(d);
   Image3D_I  imageI = Image3D_I(d);
   Image  image = Image(d);
-
+  if (customBGColor.size() == 3)
+  {
+      viewer.myDefaultBackgroundColor = DGtal::Color(customBGColor[0],
+                                              customBGColor[1],
+                                              customBGColor[2], 255);
+      viewer.update();
+      viewer.draw();
+   }
   if(extension != "sdp")
   {
     unsigned int numDisplayed=0;
@@ -326,26 +337,13 @@ int main( int argc, char** argv )
   }
   
   viewer << Viewer3D<>::updateDisplay;
-  if(snapShotFile != "")
-  {
-    // Appy cleaning just save the last snap
-    if(!viewer.restoreStateFromFile())
+  if(snapShotFile != "" )
     {
-      viewer.update();
-    }
-    std::string extension = snapShotFile.substr(snapShotFile.find_last_of(".") + 1);
-    std::string basename = snapShotFile.substr(0, snapShotFile.find_last_of("."));
-    for(int i=0; i< viewer.snapshotCounter()-1; i++){
-      std::stringstream s;
-      s << basename << "-"<< setfill('0') << setw(4)<<  i << "." << extension;
-      trace.info() << "erase temp file: " << s.str() << std::endl;
-      remove(s.str().c_str());
-    }
-    std::stringstream s;
-    s << basename << "-"<< setfill('0') << setw(4)<<  viewer.snapshotCounter()-1 << "." << extension;
-    rename(s.str().c_str(), snapShotFile.c_str());
-    return 0;
-  }
+      // Recover mesh position
+      viewer.restoreStateFromFile();
+      viewer.saveSnapshot(QString(snapShotFile.c_str()), true);
+      return 0;
+   }
     
   if (useLastCamSet)
   {

--- a/visualisation/meshViewer.cpp
+++ b/visualisation/meshViewer.cpp
@@ -76,7 +76,7 @@ using namespace DGtal;
  -A,--addAmbientLight FLOAT            add an ambient light for better display (between 0 and 1).
  -b,--customBGColor UINT x 3           set the R, G, B, A components of the colors of  the sdp view
  -d,--doSnapShotAndExit TEXT           save display snapshot into file. Notes that the camera                                             setting is set by default according the last saved                                                 configuration (use SHIFT+Key_M to save current camera                                              setting in the Viewer3D). If the camera setting was not                                            saved it will use the default camera setting.
- -c,--useLastCameraSetting             use the last camera setting of the user (i.e if a                                                  .qglviewer.xml file is present in the current directory)
+ -c,--useLastCameraSetting             use the last camera setting of the user (i.e if a .qglviewer.xml file is present in the current directory)
  -l,--fixLightToScene                  Fix light source to scence instead to camera
  -n,--invertNormal                     invert face normal vectors.
  -v,--drawVertex                       draw the vertex of the mesh

--- a/visualisation/meshViewer.cpp
+++ b/visualisation/meshViewer.cpp
@@ -136,6 +136,12 @@ protected:
   };
   
 public: 
+  void changeDefaultBGColor(const DGtal::Color &col)
+    {
+         myDefaultBackgroundColor = col;
+         Viewer3D<>::update();
+         Viewer3D<>::draw();
+      }
   std::string myInfoDisplay = "No information loaded...";
   bool myIsDisplayingInfoMode = false;
   DGtal::Z3i::RealPoint centerMesh;
@@ -168,6 +174,7 @@ int main( int argc, char** argv )
   std::vector<unsigned int > customColorMesh;
   std::vector<unsigned int > customColorSDP;
   std::vector<unsigned int > customLineColor;
+  std::vector<unsigned int > customBGColor;
   std::vector<unsigned int > vectFieldIndices = {0,1,2,3,4,5};
   std::string displayVectorField;
   
@@ -203,6 +210,8 @@ int main( int argc, char** argv )
   app.add_option("--SDPradius", ballRadius, "change the ball radius to display a set of discrete points (used with displaySDP option)", true);
   app.add_option("--displaySDP,-s", filenameSDP,  "add the display of a set of discrete points as ball of radius 0.5.");
   app.add_option("--addAmbientLight,-A", ambiantLight, "add an ambient light for better display (between 0 and 1)." );
+  app.add_option("--customBGColor,-b", customBGColor, "set the R, G, B, A components of the colors of  the sdp view")
+    ->expected(3);
   app.add_option("--doSnapShotAndExit,-d", snapshotFile, "save display snapshot into file. Notes that the camera setting is set by default according the last saved configuration (use SHIFT+Key_M to save current camera setting in the Viewer3D). If the camera setting was not saved it will use the default camera setting.");
   app.add_flag("--invertNormal,-n", invertNormal, "invert face normal vectors.");
   app.add_flag("--drawVertex,-v", drawVertex, "draw the vertex of the mesh");
@@ -252,6 +261,7 @@ int main( int argc, char** argv )
   
   QApplication application(argc,argv);
   CustomViewer3D viewer;
+  
   if(snapshotFile != "")
   {
     viewer.setSnapshotFileName(QString(snapshotFile.c_str()));
@@ -263,7 +273,11 @@ int main( int argc, char** argv )
   viewer.show();
   viewer.myGLLineMinWidth = lineWidth;
   viewer.setGLScale(sx, sy, sz);
-  
+  if (customBGColor.size() != 0){
+        viewer.changeDefaultBGColor(DGtal::Color(customBGColor[0],
+                                                 customBGColor[1],
+                                                 customBGColor[2], 255));
+  }
   if(ambiantLight != 0.0)
   {
     GLfloat lightAmbientCoeffs [4] = {ambiantLight,ambiantLight, ambiantLight, 1.0f};

--- a/visualisation/meshViewer.cpp
+++ b/visualisation/meshViewer.cpp
@@ -110,10 +110,9 @@ protected:
     Viewer3D<>::init();
     Viewer3D<>::setKeyDescription ( Qt::Key_I, "Display mesh informations about #faces, #vertices" );
     Viewer3D<>::setGLDoubleRenderingMode(false);
-    if(mySaveSnap){
-      QObject::connect(this, SIGNAL(drawFinished(bool)), this, SLOT(saveSnapshot(bool)));
-    }
+   
   }
+  
   virtual void keyPressEvent(QKeyEvent *e){
     bool handled = false;
     if( e->key() == Qt::Key_I)
@@ -139,7 +138,6 @@ protected:
 public: 
   std::string myInfoDisplay = "No information loaded...";
   bool myIsDisplayingInfoMode = false;
-  bool mySaveSnap = false;
   DGtal::Z3i::RealPoint centerMesh;
 };
 
@@ -254,7 +252,6 @@ int main( int argc, char** argv )
   
   QApplication application(argc,argv);
   CustomViewer3D viewer;
-  viewer.mySaveSnap = snapshotFile != "";
   if(snapshotFile != "")
   {
     viewer.setSnapshotFileName(QString(snapshotFile.c_str()));
@@ -360,23 +357,9 @@ int main( int argc, char** argv )
   viewer  << CustomViewer3D::updateDisplay;
   if(snapshotFile != "" )
   {
-    // Appy cleaning just save the last snap
-    if(!viewer.restoreStateFromFile())
-    {
-      viewer.update();
-    }
-    std::string extension = snapshotFile.substr(snapshotFile.find_last_of(".") + 1);
-    std::string basename = snapshotFile.substr(0, snapshotFile.find_last_of("."));
-    for(int i=0; i< viewer.snapshotCounter()-1; i++){
-      std::stringstream s;
-      s << basename << "-"<< setfill('0') << setw(4)<<  i << "." << extension;
-      trace.info() << "erase temp file: " << s.str() << std::endl;
-      remove(s.str().c_str());
-    }
-    
-    std::stringstream s;
-    s << basename << "-"<< setfill('0') << setw(4)<<  viewer.snapshotCounter()-1 << "." << extension;
-    rename(s.str().c_str(), snapshotFile.c_str());
+    // Recover mesh position
+    viewer.restoreStateFromFile();
+    viewer.saveSnapshot(QString(snapshotFile.c_str()), true);
     return 0;
   }
   

--- a/visualisation/meshViewer.cpp
+++ b/visualisation/meshViewer.cpp
@@ -74,7 +74,7 @@ using namespace DGtal;
  --SDPradius FLOAT=0.5                 change the ball radius to display a set of discrete points (used with displaySDP option)
  -s,--displaySDP TEXT                  add the display of a set of discrete points as ball of radius 0.5.
  -A,--addAmbientLight FLOAT            add an ambient light for better display (between 0 and 1).
- -b,--customBGColor UINT x 3           set the R, G, B, A components of the colors of  the sdp view
+ -b,--customBGColor UINT x 3           set the R, G, B components of the colors of the background color.
  -d,--doSnapShotAndExit TEXT           save display snapshot into file. Notes that the camera                                             setting is set by default according the last saved                                                 configuration (use SHIFT+Key_M to save current camera                                              setting in the Viewer3D). If the camera setting was not                                            saved it will use the default camera setting.
  -c,--useLastCameraSetting             use the last camera setting of the user (i.e if a                                                  .qglviewer.xml file is present in the current directory)
  -l,--fixLightToScene                  Fix light source to scence instead to camera
@@ -214,7 +214,7 @@ int main( int argc, char** argv )
   app.add_option("--SDPradius", ballRadius, "change the ball radius to display a set of discrete points (used with displaySDP option)", true);
   app.add_option("--displaySDP,-s", filenameSDP,  "add the display of a set of discrete points as ball of radius 0.5.");
   app.add_option("--addAmbientLight,-A", ambiantLight, "add an ambient light for better display (between 0 and 1)." );
-  app.add_option("--customBGColor,-b", customBGColor, "set the R, G, B, A components of the colors of  the sdp view")
+  app.add_option("--customBGColor,-b", customBGColor, "set the R, G, B components of the colors of the background color.")
     ->expected(3);
   app.add_option("--doSnapShotAndExit,-d", snapshotFile, "save display snapshot into file. Notes that the camera setting is set by default according the last saved configuration (use SHIFT+Key_M to save current camera setting in the Viewer3D). If the camera setting was not saved it will use the default camera setting.");
   app.add_flag("--useLastCameraSetting,-c", useLastCamSet, "use the last camera setting of the user (i.e if a .qglviewer.xml file is present in the current directory)");

--- a/visualisation/meshViewer.cpp
+++ b/visualisation/meshViewer.cpp
@@ -184,6 +184,7 @@ int main( int argc, char** argv )
   bool invertNormal {false};
   bool drawVertex {false};
   bool useLastCamSet {false};
+  bool fixLightToScene {false};
   float ambiantLight {0.0};
   
   
@@ -215,6 +216,7 @@ int main( int argc, char** argv )
     ->expected(3);
   app.add_option("--doSnapShotAndExit,-d", snapshotFile, "save display snapshot into file. Notes that the camera setting is set by default according the last saved configuration (use SHIFT+Key_M to save current camera setting in the Viewer3D). If the camera setting was not saved it will use the default camera setting.");
   app.add_flag("--useLastCameraSetting,-c", useLastCamSet, "use the last camera setting of the user (i.e if a .qglviewer.xml file is present in the current directory)");
+  app.add_flag("--fixLightToScene,-l", fixLightToScene, "Fix light source to scence instead to camera");
   app.add_flag("--invertNormal,-n", invertNormal, "invert face normal vectors.");
   app.add_flag("--drawVertex,-v", drawVertex, "draw the vertex of the mesh");
   
@@ -371,9 +373,17 @@ int main( int argc, char** argv )
   ss << "# faces: " << std::fixed << nbFaces << "    #vertex: " <<  nbVertex ;
   viewer.myInfoDisplay = ss.str();
   viewer  << CustomViewer3D::updateDisplay;
-  if (useLastCamSet) {
+  if (fixLightToScene)
+  {
+        viewer.setLightModeFixToCamera(false, false);
+  }
+
+  if (useLastCamSet)
+  {
       viewer.restoreStateFromFile();
-  }else{
+  }
+  else
+  {
       // useful in non interactive case in order to retain the default camera settings (that are not saved in case of process kill).
       viewer.saveStateToFile();
   }
@@ -384,6 +394,5 @@ int main( int argc, char** argv )
     viewer.saveSnapshot(QString(snapshotFile.c_str()), true);
     return 0;
   }
-
   return application.exec();
 }

--- a/visualisation/meshViewer.cpp
+++ b/visualisation/meshViewer.cpp
@@ -410,6 +410,7 @@ int main( int argc, char** argv )
     viewer.saveSnapshot(QString(snapshotFile.c_str()), true);
     return 0;
   }
- 
+  trace.info() << "[display ready]"<< std::endl;
+
   return application.exec();
 }

--- a/visualisation/meshViewer.cpp
+++ b/visualisation/meshViewer.cpp
@@ -183,6 +183,7 @@ int main( int argc, char** argv )
   double ballRadius {0.5};
   bool invertNormal {false};
   bool drawVertex {false};
+  bool useLastCamSet {false};
   float ambiantLight {0.0};
   
   
@@ -213,6 +214,7 @@ int main( int argc, char** argv )
   app.add_option("--customBGColor,-b", customBGColor, "set the R, G, B, A components of the colors of  the sdp view")
     ->expected(3);
   app.add_option("--doSnapShotAndExit,-d", snapshotFile, "save display snapshot into file. Notes that the camera setting is set by default according the last saved configuration (use SHIFT+Key_M to save current camera setting in the Viewer3D). If the camera setting was not saved it will use the default camera setting.");
+  app.add_flag("--useLastCameraSetting,-c", useLastCamSet, "use the last camera setting of the user (i.e if a .qglviewer.xml file is present in the current directory)");
   app.add_flag("--invertNormal,-n", invertNormal, "invert face normal vectors.");
   app.add_flag("--drawVertex,-v", drawVertex, "draw the vertex of the mesh");
   
@@ -369,6 +371,9 @@ int main( int argc, char** argv )
   ss << "# faces: " << std::fixed << nbFaces << "    #vertex: " <<  nbVertex ;
   viewer.myInfoDisplay = ss.str();
   viewer  << CustomViewer3D::updateDisplay;
+  if (useLastCamSet) {
+      viewer.restoreStateFromFile();
+  }
   if(snapshotFile != "" )
   {
     // Recover mesh position

--- a/visualisation/meshViewer.cpp
+++ b/visualisation/meshViewer.cpp
@@ -265,7 +265,7 @@ int main( int argc, char** argv )
   viewer.show();
   viewer.myGLLineMinWidth = lineWidth;
   viewer.setGLScale(sx, sy, sz);
-  if (customBGColor.size() != 0){
+  if (customBGColor.size() == 3){
         viewer.changeDefaultBGColor(DGtal::Color(customBGColor[0],
                                                  customBGColor[1],
                                                  customBGColor[2], 255));

--- a/visualisation/meshViewer.cpp
+++ b/visualisation/meshViewer.cpp
@@ -74,10 +74,12 @@ using namespace DGtal;
  --SDPradius FLOAT=0.5                 change the ball radius to display a set of discrete points (used with displaySDP option)
  -s,--displaySDP TEXT                  add the display of a set of discrete points as ball of radius 0.5.
  -A,--addAmbientLight FLOAT            add an ambient light for better display (between 0 and 1).
- -d,--doSnapShotAndExit TEXT           save display snapshot into file. Notes that the camera setting is set by default according the last saved configuration (use SHIFT+Key_M to save current camera setting in the Viewer3D). If the camera setting was not saved it will use the default camera setting.
+ -b,--customBGColor UINT x 3           set the R, G, B, A components of the colors of  the sdp view
+ -d,--doSnapShotAndExit TEXT           save display snapshot into file. Notes that the camera                                             setting is set by default according the last saved                                                 configuration (use SHIFT+Key_M to save current camera                                              setting in the Viewer3D). If the camera setting was not                                            saved it will use the default camera setting.
+ -c,--useLastCameraSetting             use the last camera setting of the user (i.e if a                                                  .qglviewer.xml file is present in the current directory)
+ -l,--fixLightToScene                  Fix light source to scence instead to camera
  -n,--invertNormal                     invert face normal vectors.
  -v,--drawVertex                       draw the vertex of the mesh
- 
  
  @endcode
  
@@ -265,7 +267,6 @@ int main( int argc, char** argv )
   
   QApplication application(argc,argv);
   CustomViewer3D viewer;
-  
   if(snapshotFile != "")
   {
     viewer.setSnapshotFileName(QString(snapshotFile.c_str()));
@@ -375,7 +376,7 @@ int main( int argc, char** argv )
   viewer  << CustomViewer3D::updateDisplay;
   if (fixLightToScene)
   {
-        viewer.setLightModeFixToCamera(false, false);
+      viewer.setLightModeFixToCamera(false, false);
   }
 
   if (useLastCamSet)

--- a/visualisation/meshViewer.cpp
+++ b/visualisation/meshViewer.cpp
@@ -373,6 +373,9 @@ int main( int argc, char** argv )
   viewer  << CustomViewer3D::updateDisplay;
   if (useLastCamSet) {
       viewer.restoreStateFromFile();
+  }else{
+      // useful in non interactive case in order to retain the default camera settings (that are not saved in case of process kill).
+      viewer.saveStateToFile();
   }
   if(snapshotFile != "" )
   {
@@ -381,7 +384,6 @@ int main( int argc, char** argv )
     viewer.saveSnapshot(QString(snapshotFile.c_str()), true);
     return 0;
   }
-  // useful in non interactive case in order to retain the default camera settings (that are not saved in case of process kill).
-  viewer.saveStateToFile();
+
   return application.exec();
 }

--- a/visualisation/meshViewer.cpp
+++ b/visualisation/meshViewer.cpp
@@ -237,24 +237,11 @@ int main( int argc, char** argv )
   
   if( customColorMesh.size() != 0 )
   {
-    if(customColorMesh.size()!=4 && customColorMesh.size()!=8 )
+    if(customColorMesh.size()<4 )
     {
       trace.error() << "colors specification should contain R,G,B and Alpha values"<< std::endl;
     }
-    if( customColorMesh.size() >= 4)
-    {
-      meshColorR = customColorMesh[0];
-      meshColorG = customColorMesh[1];
-      meshColorB = customColorMesh[2];
-      meshColorA = customColorMesh[3];
-    }
-    if(customColorMesh.size() == 8)
-    {
-      meshColorRLine = customColorMesh[4];
-      meshColorGLine = customColorMesh[5];
-      meshColorBLine = customColorMesh[6];
-      meshColorALine = customColorMesh[7];
-    }
+      
   }
   
   if(customColorSDP.size() == 4)
@@ -296,6 +283,16 @@ int main( int argc, char** argv )
   {
     Mesh<DGtal::Z3i::RealPoint> aMesh(customColorMesh.size() != 4 && customColorMesh.size() != 8);
     aMesh << inputFileNames[i];
+      // for obj mesh by default the mesh color face are not necessary uniform.
+      if (aMesh.isStoringFaceColors() && customColorMesh.size() >= 4 ){
+          if ( i*8 < customColorMesh.size() ) {meshColorR = customColorMesh[i*8];}
+          if ( i*8+1< customColorMesh.size() ) {meshColorG = customColorMesh[i*8+1];}
+          if ( i*8+2 < customColorMesh.size() ) {meshColorB = customColorMesh[i*8+2];}
+          if ( i*8+3 < customColorMesh.size() ) {meshColorA = customColorMesh[i*8+3];}
+          for (unsigned int j = 0; j < aMesh.nbFaces(); j++){
+              aMesh.setFaceColor(j, Color(meshColorR, meshColorG, meshColorB, meshColorA));
+          }
+      }
     vectMesh.push_back(aMesh);
   }
   DGtal::Z3i::RealPoint centerMeshes;
@@ -333,10 +330,21 @@ int main( int argc, char** argv )
     }
   }
   
-  viewer << CustomColors3D(Color(meshColorRLine, meshColorGLine, meshColorBLine, meshColorALine),
-                           Color(meshColorR, meshColorG, meshColorB, meshColorA));
-  for(unsigned int i=0; i<vectMesh.size(); i++){
-    viewer << vectMesh[i];
+   for(unsigned int i=0; i<vectMesh.size(); i++){
+       if ( i*8 < customColorMesh.size() ) {meshColorR = customColorMesh[i*8];}
+       if ( i*8+1< customColorMesh.size() ) {meshColorG = customColorMesh[i*8+1];}
+       if ( i*8+2 < customColorMesh.size() ) {meshColorB = customColorMesh[i*8+2];}
+       if ( i*8+3 < customColorMesh.size() ) {meshColorA = customColorMesh[i*8+3];}
+       if ( i*8+4 < customColorMesh.size() ) {meshColorALine = customColorMesh[i*8+4];}
+       if ( i*8+5< customColorMesh.size() ) {meshColorBLine = customColorMesh[i*8+5];}
+       if ( i*8+6 < customColorMesh.size() ) {meshColorRLine = customColorMesh[i*8+6];}
+       if ( i*8+7 < customColorMesh.size() ) {meshColorALine = customColorMesh[i*8+7];}
+
+       viewer << CustomColors3D(Color(meshColorRLine, meshColorGLine, meshColorBLine,
+                                      meshColorALine),
+                                Color(meshColorR, meshColorG, meshColorB, meshColorA));
+
+      viewer << vectMesh[i];
   }
   
   if(drawVertex){

--- a/visualisation/meshViewer.cpp
+++ b/visualisation/meshViewer.cpp
@@ -381,6 +381,7 @@ int main( int argc, char** argv )
     viewer.saveSnapshot(QString(snapshotFile.c_str()), true);
     return 0;
   }
-  
+  // useful in non interactive case in order to retain the default camera settings (that are not saved in case of process kill).
+  viewer.saveStateToFile();
   return application.exec();
 }

--- a/visualisation/meshViewer.cpp
+++ b/visualisation/meshViewer.cpp
@@ -221,7 +221,7 @@ int main( int argc, char** argv )
   app.add_flag("--fixLightToScene,-l", fixLightToScene, "Fix light source to scence instead to camera");
   app.add_flag("--invertNormal,-n", invertNormal, "invert face normal vectors.");
   app.add_flag("--drawVertex,-v", drawVertex, "draw the vertex of the mesh");
-  
+
   
   app.get_formatter()->column_width(40);
   CLI11_PARSE(app, argc, argv);
@@ -396,6 +396,13 @@ int main( int argc, char** argv )
       // useful in non interactive case in order to retain the default camera settings (that are not saved in case of process kill).
       viewer.saveStateToFile();
   }
+  // First display transparency improve
+  viewer.sortTriangleFromCamera();
+  viewer.sortQuadFromCamera();
+  viewer.sortSurfelFromCamera();
+  viewer.sortPolygonFromCamera();
+  viewer  << CustomViewer3D::updateDisplay;
+  
   if(snapshotFile != "" )
   {
     // Recover mesh position
@@ -403,5 +410,6 @@ int main( int argc, char** argv )
     viewer.saveSnapshot(QString(snapshotFile.c_str()), true);
     return 0;
   }
+ 
   return application.exec();
 }


### PR DESCRIPTION
# PR Description
 -meshViewer: new options to change the default background color, to
    load camera settings at startup, to change at startup the light
    source mode attached or not to the camera and improve transparency
    process at startup rendering. It includes a fix of the
    -customColorMesh for obj mesh and add new possibilities to custom
    the color of each mesh given as input. It also includes a fix and
    some simplications of the option --doSnapShotAndExit.

# Checklist

- [x] Doxygen documentation of the code completed (classes, methods, types, members...).
- [x] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [x] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Github Actions & appveyor).
