### PR TITLE
mesh2vol digitization space option

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,7 +18,9 @@
 - *converters*
    - mesh2vol: small fix to read generic mesh. 
      (Bertrand Kerautret [#444](https://github.com/DGtal-team/DGtal/pull/444))
- 
+   - mesh2vol: use the digitization space defined from bounding box of input mesh. 
+     (Bertrand Kerautret [#450](https://github.com/DGtal-team/DGtal/pull/450))
+     
 
 
 

--- a/converters/mesh2vol.cpp
+++ b/converters/mesh2vol.cpp
@@ -53,7 +53,7 @@ using namespace DGtal;
 @b Allowed @b options @b are:
 
 @code
-ositionals:
+positionals:
   1 TEXT:FILE REQUIRED                  mesh file (.off).
   2 TEXT=result.vol                     filename of ouput volumetric file (vol, pgm3d, ...).
 
@@ -62,6 +62,7 @@ Options:
   -i,--input TEXT:FILE REQUIRED         mesh file (.off).
   -o,--output TEXT=result.vol           filename of ouput volumetric file (vol, pgm3d, ...).
   -m,--margin UINT                      add volume margin around the mesh bounding box.
+  -d,--objectDomainBB                   use the digitization space defined from bounding box of input mesh. If seleted, the option --resolution will have no effect.
   -s,--separation UINT:{6,26}=6         voxelization 6-separated or 26-separated.
   -r,--resolution UINT=128              digitization domain size (e.g. 128). The mesh will be scaled such that its bounding box maps to [0,resolution)^3.
 @endcode
@@ -94,21 +95,28 @@ void voxelizeAndExport(const std::string& inputFilename,
   trace.info()<< "Mesh bounding box: "<<bbox.first <<" "<<bbox.second<<std::endl;
 
   const double smax = (bbox.second - bbox.first).max();
-  const double factor = resolution / smax;
-  const PointR3 translate = -bbox.first;
-  trace.info() << "Scale = "<<factor<<" translate = "<<translate<<std::endl;
-  for(auto it = inputMesh.vertexBegin(), itend = inputMesh.vertexEnd();
-      it != itend; ++it)
+  if (resolution != 0)
   {
-    //scale + translation
-    *it += translate;
-    *it *= factor;
+    const double factor = resolution / smax;
+    const PointR3 translate = -bbox.first;
+    trace.info() << "Scale = "<<factor<<" translate = "<<translate<<std::endl;
+    for(auto it = inputMesh.vertexBegin(), itend = inputMesh.vertexEnd();
+        it != itend; ++it)
+    {
+      //scale + translation
+      *it += translate;
+      *it *= factor;
+    }
+    trace.endBlock();
   }
-  trace.endBlock();
-  
   trace.beginBlock("Voxelization");
   trace.info() << "Voxelization " << SEP << "-separated ; " << resolution << "^3 ";
   Domain aDomain(PointZ3().diagonal(-margin), PointZ3().diagonal(resolution+margin));
+  if (resolution == 0)
+  {
+    aDomain = Domain(bbox.first, bbox.second);
+    
+  }
   
   //Digitization step
   Z3i::DigitalSet mySet(aDomain);
@@ -137,7 +145,8 @@ int main( int argc, char** argv )
    unsigned int margin  {0};
    unsigned int separation {6};
    unsigned int resolution {128};
- 
+   bool unitScale {false};
+   
    app.description("Convert a mesh file into a 26-separated or 6-separated volumetric voxelization in a given resolution grid. \n Example:\n mesh2vol ${DGtal}/examples/samples/tref.off output.vol --separation 26 --resolution 256 ");
    
    app.add_option("-i,--input,1", inputFileName, "mesh file (.off)." )
@@ -145,6 +154,7 @@ int main( int argc, char** argv )
      ->check(CLI::ExistingFile);
    app.add_option("-o,--output,2", outputFileName, "filename of ouput volumetric file (vol, pgm3d, ...).",true);
    app.add_option("-m,--margin", margin, "add volume margin around the mesh bounding box.");
+   app.add_flag("-d,--objectDomainBB", unitScale, "use the digitization space defined from bounding box of input mesh. If seleted, the option --resolution will have no effect.");
    app.add_option("-s,--separation", separation, "voxelization 6-separated or 26-separated.", true)
      -> check(CLI::IsMember({6, 26}));
    app.add_option("-r,--resolution", resolution,"digitization domain size (e.g. 128). The mesh will be scaled such that its bounding box maps to [0,resolution)^3.", true);
@@ -153,11 +163,11 @@ int main( int argc, char** argv )
   app.get_formatter()->column_width(40);
   CLI11_PARSE(app, argc, argv);
   // END parse command line using CLI ----------------------------------------------    
- 
+       
   if (separation==6)
-    voxelizeAndExport<6>(inputFileName, outputFileName, resolution, margin);
+       voxelizeAndExport<6>(inputFileName, outputFileName, unitScale ? 0 : resolution, margin);
   else
-    voxelizeAndExport<26>(inputFileName, outputFileName, resolution, margin);    
+    voxelizeAndExport<26>(inputFileName, outputFileName, unitScale ? 0 : resolution, margin);    
  return EXIT_SUCCESS;
 }
 

--- a/converters/mesh2vol.cpp
+++ b/converters/mesh2vol.cpp
@@ -80,7 +80,8 @@ template< unsigned int SEP >
 void voxelizeAndExport(const std::string& inputFilename,
                        const std::string& outputFilename,
                        const unsigned int resolution,
-                       const unsigned int margin)
+                       const unsigned int margin,
+                       const unsigned char fillVal)
 {
   using Domain   = Z3i::Domain;
   using PointR3  = Z3i::RealPoint;
@@ -130,7 +131,7 @@ void voxelizeAndExport(const std::string& inputFilename,
   trace.info()<<aDomain<<std::endl;
   ImageContainerBySTLVector<Domain, unsigned char> image(aDomain);
   for(auto p: mySet)
-    image.setValue(p, 128);
+    image.setValue(p, fillVal);
   image >> outputFilename.c_str();
   trace.endBlock();
 }
@@ -145,6 +146,7 @@ int main( int argc, char** argv )
    unsigned int margin  {0};
    unsigned int separation {6};
    unsigned int resolution {128};
+   unsigned char fillValue {128};
    bool unitScale {false};
    
    app.description("Convert a mesh file into a 26-separated or 6-separated volumetric voxelization in a given resolution grid. \n Example:\n mesh2vol ${DGtal}/examples/samples/tref.off output.vol --separation 26 --resolution 256 ");
@@ -155,6 +157,7 @@ int main( int argc, char** argv )
    app.add_option("-o,--output,2", outputFileName, "filename of ouput volumetric file (vol, pgm3d, ...).",true);
    app.add_option("-m,--margin", margin, "add volume margin around the mesh bounding box.");
    app.add_flag("-d,--objectDomainBB", unitScale, "use the digitization space defined from bounding box of input mesh. If seleted, the option --resolution will have no effect.");
+   app.add_option("-f,--fillValue", fillValue, "change the default value of filling value of the volumetric image.")
    app.add_option("-s,--separation", separation, "voxelization 6-separated or 26-separated.", true)
      -> check(CLI::IsMember({6, 26}));
    app.add_option("-r,--resolution", resolution,"digitization domain size (e.g. 128). The mesh will be scaled such that its bounding box maps to [0,resolution)^3.", true);
@@ -165,9 +168,9 @@ int main( int argc, char** argv )
   // END parse command line using CLI ----------------------------------------------    
        
   if (separation==6)
-       voxelizeAndExport<6>(inputFileName, outputFileName, unitScale ? 0 : resolution, margin);
+       voxelizeAndExport<6>(inputFileName, outputFileName, unitScale ? 0 : resolution, margin, fillValue);
   else
-    voxelizeAndExport<26>(inputFileName, outputFileName, unitScale ? 0 : resolution, margin);    
+    voxelizeAndExport<26>(inputFileName, outputFileName, unitScale ? 0 : resolution, margin, fillValue);    
  return EXIT_SUCCESS;
 }
 

--- a/converters/mesh2vol.cpp
+++ b/converters/mesh2vol.cpp
@@ -64,6 +64,7 @@ Options:
   -m,--margin UINT                      add volume margin around the mesh bounding box.
   -d,--objectDomainBB                   use the digitization space defined from bounding box of input mesh. If seleted, the option --resolution will have no effect.
   -s,--separation UINT:{6,26}=6         voxelization 6-separated or 26-separated.
+  -f,--fillValue                                        change the default output  volumetric image value in [1...255].
   -r,--resolution UINT=128              digitization domain size (e.g. 128). The mesh will be scaled such that its bounding box maps to [0,resolution)^3.
 @endcode
 
@@ -156,7 +157,8 @@ int main( int argc, char** argv )
    app.add_option("-o,--output,2", outputFileName, "filename of ouput volumetric file (vol, pgm3d, ...).",true);
    app.add_option("-m,--margin", margin, "add volume margin around the mesh bounding box.");
    app.add_flag("-d,--objectDomainBB", unitScale, "use the digitization space defined from bounding box of input mesh. If seleted, the option --resolution will have no effect.");
-   app.add_option("-f,--fillValue", fillValue, "change the default output  volumetric image value in [1...255].");
+   app.add_option("-f,--fillValue", fillValue, "change the default output  volumetric image value in [1...255].")
+   ->expected(0, 255);
    app.add_option("-s,--separation", separation, "voxelization 6-separated or 26-separated.", true)
      -> check(CLI::IsMember({6, 26}));
    app.add_option("-r,--resolution", resolution,"digitization domain size (e.g. 128). The mesh will be scaled such that its bounding box maps to [0,resolution)^3.", true);

--- a/converters/mesh2vol.cpp
+++ b/converters/mesh2vol.cpp
@@ -157,7 +157,7 @@ int main( int argc, char** argv )
    app.add_option("-o,--output,2", outputFileName, "filename of ouput volumetric file (vol, pgm3d, ...).",true);
    app.add_option("-m,--margin", margin, "add volume margin around the mesh bounding box.");
    app.add_flag("-d,--objectDomainBB", unitScale, "use the digitization space defined from bounding box of input mesh. If seleted, the option --resolution will have no effect.");
-   app.add_option("-f,--fillValue", fillValue, "change the default value of filling value of the volumetric image.")
+   app.add_option("-f,--fillValue", fillValue, "change the default value of filling value of the volumetric image.");
    app.add_option("-s,--separation", separation, "voxelization 6-separated or 26-separated.", true)
      -> check(CLI::IsMember({6, 26}));
    app.add_option("-r,--resolution", resolution,"digitization domain size (e.g. 128). The mesh will be scaled such that its bounding box maps to [0,resolution)^3.", true);

--- a/converters/mesh2vol.cpp
+++ b/converters/mesh2vol.cpp
@@ -116,7 +116,6 @@ void voxelizeAndExport(const std::string& inputFilename,
   if (resolution == 0)
   {
     aDomain = Domain(bbox.first, bbox.second);
-    
   }
   
   //Digitization step
@@ -157,7 +156,7 @@ int main( int argc, char** argv )
    app.add_option("-o,--output,2", outputFileName, "filename of ouput volumetric file (vol, pgm3d, ...).",true);
    app.add_option("-m,--margin", margin, "add volume margin around the mesh bounding box.");
    app.add_flag("-d,--objectDomainBB", unitScale, "use the digitization space defined from bounding box of input mesh. If seleted, the option --resolution will have no effect.");
-   app.add_option("-f,--fillValue", fillValue, "change the default value of filling value of the volumetric image.");
+   app.add_option("-f,--fillValue", fillValue, "change the default output  volumetric image value in [1...255].");
    app.add_option("-s,--separation", separation, "voxelization 6-separated or 26-separated.", true)
      -> check(CLI::IsMember({6, 26}));
    app.add_option("-r,--resolution", resolution,"digitization domain size (e.g. 128). The mesh will be scaled such that its bounding box maps to [0,resolution)^3.", true);


### PR DESCRIPTION
# PR Description
New option in mesh2vol useful to keep the digitization space defined from bounding box of input mesh. 

# Checklist

- [ ] Doxygen documentation of the code completed (classes, methods, types, members...).
- [ ] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [ ] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [ ] Update the readme with potentially a screenshot of the tools if it applies. 
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Github Actions & appveyor).
