### PR TITLE
Add colored alpha SDP in meshViewer and alpha mesh in 3dSDPViewer

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,13 @@
   - meshViewer: new option to set alpha channel of the mesh color.
   (Bertrand  Kerautret
     [#451](https://github.com/DGtal-team/DGtalTools/pull/451))
+  - 3dSDPViewer: new option to set alpha channel of the mesh color.
+  (Xun Gong
+    [#452](https://github.com/DGtal-team/DGtalTools/pull/452))
+  - meshViewer: Add colored SDP option in meshViewer when input texts is an alpha mesh and a colored SDP respectively.
+  (Xun Gong
+    [#452](https://github.com/DGtal-team/DGtalTools/pull/452))
+
 - *volumetric*
     - volReSample: fix the impossibility to export to vol when ITK is activated
       (Bertrand Kerautret [#445](https://github.com/DGtal-team/DGtalTools/pull/445))

--- a/visualisation/3dSDPViewer.cpp
+++ b/visualisation/3dSDPViewer.cpp
@@ -45,8 +45,6 @@
 
 #include "CLI11.hpp"
 
-
-
 using namespace std;
 using namespace DGtal;
 using namespace Z3i;
@@ -55,13 +53,13 @@ typedef Viewer3D<Z3i::Space, Z3i::KSpace> Viewer;
 
 /**
  @page Doc3DSDPViewer 3DSDPViewer
- 
+
  @brief Displays a  sequence of 3d discrete points by using QGLviewer.
 
  @b Usage:  3dSDPViewer [OPTIONS] 1 [f] [lineSize] [filterVectors]
 
  @b Allowed @b options @b are :
- 
+
  @code
 
  Positionals:
@@ -75,6 +73,7 @@ typedef Viewer3D<Z3i::Space, Z3i::KSpace> Viewer;
    -l,--lineColor INT x 4                set the color of line: r g b a.
    -m,--addMesh TEXT                     append a mesh (off/obj) to the point set visualization.
    --customColorMesh UINT x 4            set the R, G, B, A components of the colors of the mesh faces (mesh added with option --addMesh).
+   --customAlphaMesh UINT                set single alpha(A) components of the colors of the mesh faces (mesh added with option --addMesh).
    --importColors                        import point colors from the input file (R G B colors should be by default at index 3, 4, 5).
    --setColorsIndex UINT x 3 Needs: --importColors
                                          customize the index of the imported colors in the source file (used by --importColor). By default the initial indexes are 3, 4, 5.
@@ -96,11 +95,11 @@ typedef Viewer3D<Z3i::Space, Z3i::KSpace> Viewer;
    -u,--unitVector FLOAT=0               specifies that the SDP vector file format (of --drawVectors option) should be interpreted as unit vectors (each vector position is be defined from the input point (with input order) with a constant norm defined by [arg]).
    --filterVectors FLOAT=100             filters vector input file in order to display only the [arg] percent of the input vectors (uniformly selected, to be used with option --drawVectors else no effect).
    --interactiveDisplayVoxCoords          by using this option the coordinates can be displayed after selection (shift+left click on voxel).
-  
+
 @endcode
 
 
- @b Basic @b example: 
+ @b Basic @b example:
 
  You can display a set of 3D points with sphere primitive and lines:
  @code
@@ -115,14 +114,14 @@ typedef Viewer3D<Z3i::Space, Z3i::KSpace> Viewer;
 @b Example @b with @b interactive @b selection :
 
 This tool can be useful to recover coordinates from a set of voxels. To do it, you have to add the option allowing to activate the interactive selection (with --interactiveDisplayVoxCoords), for instance if you apply:
-@code 
+@code
 $ 3dSDPViewer  $DGtal/tests/samples/sinus3D.dat  --interactiveDisplayVoxCoords
- 
-@endcode 
+
+@endcode
 you should be able to select a voxel by using the SHIFT key and by clicking on a voxel:
   @image html res3DSDPViewerInteractive.png " "
 
- 
+
 @b Visualization @b of @b large @b  point @b set
 
 If you need to display an important number of points, you can use the primitive @e glPoints instead @e voxel or @e sphere (-p glPoints). You will obtain such type of a visualization:
@@ -136,245 +135,250 @@ If you need to display an important number of points, you can use the primitive 
 
  */
 
-
-
 // call back function to display voxel coordinates
-int
-displayCoordsCallBack( void* viewer, int name, void* data )
+int displayCoordsCallBack(void *viewer, int name, void *data)
 {
-  vector<Z3i::RealPoint> *vectVoxels = (vector<Z3i::RealPoint> *) data;
+  vector<Z3i::RealPoint> *vectVoxels = (vector<Z3i::RealPoint> *)data;
   std::stringstream ss;
-  ss << "Selected voxel: (" << (*vectVoxels)[name][0] <<  ", ";
-  ss << (*vectVoxels)[name][1] <<  ", ";
-  ss << (*vectVoxels)[name][2] <<  ") ";
-  ((Viewer *) viewer)->displayMessage(QString(ss.str().c_str()), 100000);
-  
+  ss << "Selected voxel: (" << (*vectVoxels)[name][0] << ", ";
+  ss << (*vectVoxels)[name][1] << ", ";
+  ss << (*vectVoxels)[name][2] << ") ";
+  ((Viewer *)viewer)->displayMessage(QString(ss.str().c_str()), 100000);
+
   return 0;
 }
 
-
-int main( int argc, char** argv )
+int main(int argc, char **argv)
 {
   // parse command line using CLI ----------------------------------------------
   CLI::App app;
   std::string inputFileName;
-  std::vector<unsigned int > vectIndexSDP {0,1,2};
+  std::vector<unsigned int> vectIndexSDP{0, 1, 2};
   Color lineColor(100, 100, 250);
   Color pointColor(250, 250, 250);
   std::vector<int> vectColorPt;
   std::vector<int> vectColorLine;
   std::string meshName;
-  std::string typePrimitive {"voxel"};
+  std::string typePrimitive{"voxel"};
   std::string vectorsFileName;
   std::vector<double> vectSphereRadius;
   std::vector<unsigned int> vectColMesh;
-  std::vector<unsigned int> vectIndexColorImport {3,4,5};
-  bool importColorLabels {false};
-  bool noPointDisplay {false};
-  bool drawLines {false};
-  bool sphereRadiusFromInput {true};
-  bool importColors {false};
-  bool interactiveDisplayVoxCoords {false};
-  float sx {1.0};
-  float sy {1.0};
-  float sz {1.0};
-  unsigned int sphereResolution {30};
-  double sphereRadius {0.2};
-  double lineSize {0.2};
-  double filterValue {100.0};
-  double constantNorm {0.0};
-  double percentageFilterVect {100.0};
+  std::vector<unsigned int> vectIndexColorImport{3, 4, 5};
+  bool importColorLabels{false};
+  bool noPointDisplay{false};
+  bool drawLines{false};
+  bool sphereRadiusFromInput{true};
+  bool importColors{false};
+  bool interactiveDisplayVoxCoords{false};
+  float sx{1.0};
+  float sy{1.0};
+  float sz{1.0};
+  unsigned int sphereResolution{30};
+  double sphereRadius{0.2};
+  double lineSize{0.2};
+  double filterValue{100.0};
+  double constantNorm{0.0};
+  double percentageFilterVect{100.0};
+  unsigned int customAlphaMesh;
 
   unsigned int colorLabelIndex = 3;
-  
-  app.description("Display sequence of 3d discrete points by using QGLviewer.");
-  app.add_option("-i,--input,1", inputFileName, "input file: sdp (sequence of discrete points)." )
-  ->required()
-  ->check(CLI::ExistingFile);
-  app.add_option("--SDPindex",vectIndexSDP, "specify the sdp index (by default 0,1,2).")
-  ->expected(3);
-  app.add_option("--pointColor,-c",vectColorPt, "set the color of  points: r g b a.")
-  ->expected(4);
-  app.add_option("--lineColor,-l",vectColorLine, "set the color of line: r g b a.")
-  ->expected(4);
-  app.add_option("--addMesh,-m",meshName,  "append a mesh (off/obj) to the point set visualization.");
-  auto optMesh = app.add_option("--customColorMesh",vectColMesh, "set the R, G, B, A components of the colors of the mesh faces (mesh added with option --addMesh).")
-  ->expected(4);
-  auto importColOpt = app.add_flag("--importColors",importColors, "import point colors from the input file (R G B colors should be by default at index 3, 4, 5).");
-  app.add_option("--setColorsIndex", vectIndexColorImport,"customize the index of the imported colors in the source file (used by --importColor). By default the initial indexes are 3, 4, 5.")
-  ->expected(3)
-  ->needs(importColOpt);
 
-  app.add_flag("--importColorLabels", importColorLabels,"import color labels from the input file (label index  should be by default at index 3)." );
+  app.description("Display sequence of 3d discrete points by using QGLviewer.");
+  app.add_option("-i,--input,1", inputFileName, "input file: sdp (sequence of discrete points).")
+      ->required()
+      ->check(CLI::ExistingFile);
+  app.add_option("--SDPindex", vectIndexSDP, "specify the sdp index (by default 0,1,2).")
+      ->expected(3);
+  app.add_option("--pointColor,-c", vectColorPt, "set the color of  points: r g b a.")
+      ->expected(4);
+  app.add_option("--lineColor,-l", vectColorLine, "set the color of line: r g b a.")
+      ->expected(4);
+  app.add_option("--addMesh,-m", meshName, "append a mesh (off/obj) to the point set visualization.");
+  app.add_option("--customAlphaMesh", customAlphaMesh, "set the alpha components of the colors of the mesh faces (can be applied for each mesh).");
+  auto optMesh = app.add_option("--customColorMesh", vectColMesh, "set the R, G, B, A components of the colors of the mesh faces (mesh added with option --addMesh).")
+                     ->expected(4);
+  auto importColOpt = app.add_flag("--importColors", importColors, "import point colors from the input file (R G B colors should be by default at index 3, 4, 5).");
+  app.add_option("--setColorsIndex", vectIndexColorImport, "customize the index of the imported colors in the source file (used by --importColor). By default the initial indexes are 3, 4, 5.")
+      ->expected(3)
+      ->needs(importColOpt);
+
+  app.add_flag("--importColorLabels", importColorLabels, "import color labels from the input file (label index  should be by default at index 3).");
   app.add_option("--setColorLabelIndex", colorLabelIndex, "customize the index of the imported color labels in the source file (used by -importColorLabels).", true);
   app.add_option("--filter,-f", filterValue, "filter input file in order to display only the [arg] percent of the input 3D points (uniformly selected).", true);
-  app.add_flag("--noPointDisplay",noPointDisplay,  "usefull for instance to only display the lines between points." );
-  app.add_flag("--drawLines", drawLines, "draw the line between discrete points." );
-  app.add_option("--scaleX,-x", sx, "set the scale value in the X direction", true );
-  app.add_option("--scaleY,-y", sy, "set the scale value in the Y direction", true );
-  app.add_option("--scaleZ,-z", sy, "set the scale value in the Z direction", true );
-  app.add_option("--sphereResolution",sphereResolution, "defines the sphere resolution (used when the primitive is set to the sphere).", true );
+  app.add_flag("--noPointDisplay", noPointDisplay, "usefull for instance to only display the lines between points.");
+  app.add_flag("--drawLines", drawLines, "draw the line between discrete points.");
+  app.add_option("--scaleX,-x", sx, "set the scale value in the X direction", true);
+  app.add_option("--scaleY,-y", sy, "set the scale value in the Y direction", true);
+  app.add_option("--scaleZ,-z", sy, "set the scale value in the Z direction", true);
+  app.add_option("--sphereResolution", sphereResolution, "defines the sphere resolution (used when the primitive is set to the sphere).", true);
   app.add_option("-s,--sphereRadius", sphereRadius, "defines the sphere radius (used when the primitive is set to the sphere).", true);
   app.add_flag("--sphereRadiusFromInput", sphereRadiusFromInput, "takes, as sphere radius, the 4th field of the sdp input file.");
   app.add_option("--lineSize", lineSize, "defines the line size (used when the --drawLines or --drawVectors option is selected).", true);
-  app.add_option("--primitive,-p",typePrimitive, "set the primitive to display the set of points.", true )
-     -> check(CLI::IsMember({"voxel", "glPoints", "sphere"}));
-  app.add_option("--drawVectors,-v",vectorsFileName, "SDP vector file: draw a set of vectors from the given file (each vector are determined by two consecutive point given, each point represented by its coordinates on a single line.");
-  
-  app.add_option("--unitVector,-u",  constantNorm, "specifies that the SDP vector file format (of --drawVectors option) should be interpreted as unit vectors (each vector position is be defined from the input point (with input order) with a constant norm defined by [arg]).", true );
-  
-  app.add_option("--filterVectors", percentageFilterVect, "filters vector input file in order to display only the [arg] percent of the input vectors (uniformly selected, to be used with option --drawVectors else no effect). ", true );
+  app.add_option("--primitive,-p", typePrimitive, "set the primitive to display the set of points.", true)
+      ->check(CLI::IsMember({"voxel", "glPoints", "sphere"}));
+  app.add_option("--drawVectors,-v", vectorsFileName, "SDP vector file: draw a set of vectors from the given file (each vector are determined by two consecutive point given, each point represented by its coordinates on a single line.");
+
+  app.add_option("--unitVector,-u", constantNorm, "specifies that the SDP vector file format (of --drawVectors option) should be interpreted as unit vectors (each vector position is be defined from the input point (with input order) with a constant norm defined by [arg]).", true);
+
+  app.add_option("--filterVectors", percentageFilterVect, "filters vector input file in order to display only the [arg] percent of the input vectors (uniformly selected, to be used with option --drawVectors else no effect). ", true);
   app.add_flag("--interactiveDisplayVoxCoords", interactiveDisplayVoxCoords, " by using this option the coordinates can be displayed after selection (shift+left click on voxel).");
-  
-     
+
   app.get_formatter()->column_width(40);
   CLI11_PARSE(app, argc, argv);
   // END parse command line using CLI ----------------------------------------------
 
-  
-  if (vectColorLine.size() == 4){
+  if (vectColorLine.size() == 4)
+  {
     lineColor.setRGBi(vectColorLine[0], vectColorLine[1], vectColorLine[2], vectColorLine[3]);
   }
-  if (vectColorPt.size() == 4){
+  if (vectColorPt.size() == 4)
+  {
     pointColor.setRGBi(vectColorPt[0], vectColorPt[1], vectColorPt[2], vectColorPt[3]);
   }
 
-  
-  QApplication application(argc,argv);
-  
- 
+  QApplication application(argc, argv);
+
   bool useUnitVector = constantNorm != 0.0;
-  
+
   typedef Viewer3D<Z3i::Space, Z3i::KSpace> Viewer;
   Z3i::KSpace K;
-  Viewer viewer( K );
+  Viewer viewer(K);
   viewer.setWindowTitle("3dSPD Viewer");
   viewer.show();
   viewer.setGLScale(sx, sy, sz);
   viewer.myGLLineMinWidth = lineSize;
   viewer << CustomColors3D(pointColor, pointColor);
-  
-  
+
   // Get vector of colors if imported.
   std::vector<Color> vectColors;
-  if(importColors)
+  if (importColors)
   {
-    std::vector<unsigned int> r = TableReader<unsigned int>::getColumnElementsFromFile(inputFileName,vectIndexColorImport[0]);
-    std::vector<unsigned int> g = TableReader<unsigned int>::getColumnElementsFromFile(inputFileName,vectIndexColorImport[1]);
-    std::vector<unsigned int> b = TableReader<unsigned int>::getColumnElementsFromFile(inputFileName,vectIndexColorImport[2]);
-    for (unsigned int i = 0; i<r.size(); i++){
+    std::vector<unsigned int> r = TableReader<unsigned int>::getColumnElementsFromFile(inputFileName, vectIndexColorImport[0]);
+    std::vector<unsigned int> g = TableReader<unsigned int>::getColumnElementsFromFile(inputFileName, vectIndexColorImport[1]);
+    std::vector<unsigned int> b = TableReader<unsigned int>::getColumnElementsFromFile(inputFileName, vectIndexColorImport[2]);
+    for (unsigned int i = 0; i < r.size(); i++)
+    {
       vectColors.push_back(Color(r[i], g[i], b[i]));
     }
   }
 
   // Get vector of colors if imported.
-  std::vector< int> vectColorLabels;
+  std::vector<int> vectColorLabels;
   unsigned int maxLabel = 1;
-  if(importColorLabels)
+  if (importColorLabels)
   {
-    vectColorLabels = TableReader< int>::getColumnElementsFromFile(inputFileName, colorLabelIndex);
+    vectColorLabels = TableReader<int>::getColumnElementsFromFile(inputFileName, colorLabelIndex);
     maxLabel = *(std::max_element(vectColorLabels.begin(), vectColorLabels.end()));
   }
   HueShadeColorMap<unsigned int> aColorMap(0, maxLabel);
-  
-  
-  if(sphereRadiusFromInput)
+
+  if (sphereRadiusFromInput)
   {
-    vectSphereRadius = TableReader<double>::getColumnElementsFromFile(inputFileName,3);
+    vectSphereRadius = TableReader<double>::getColumnElementsFromFile(inputFileName, 3);
   }
-  
+
   vector<Z3i::RealPoint> vectVoxels;
   vectVoxels = PointListReader<Z3i::RealPoint>::getPointsFromFile(inputFileName, vectIndexSDP);
-  
+
   int name = 0;
-  if(!noPointDisplay){
+  if (!noPointDisplay)
+  {
     if (typePrimitive == "glPoints")
+    {
+      viewer.setUseGLPointForBalls(true);
+    }
+
+    int step = max(1, (int)(100 / filterValue));
+    for (unsigned int i = 0; i < vectVoxels.size(); i = i + step)
+    {
+      if (importColors)
       {
-        viewer.setUseGLPointForBalls(true);
+        Color col = vectColors[i];
+        viewer.setFillColor(col);
+      }
+      else if (importColorLabels)
+      {
+        unsigned int index = vectColorLabels[i];
+        Color col = aColorMap(index);
+        viewer.setFillColor(col);
       }
 
-    int step = max(1, (int) (100/filterValue));
-    for(unsigned int i=0;i< vectVoxels.size(); i=i+step){
-      if(importColors)
-        {
-          Color col = vectColors[i];
-          viewer.setFillColor(col);
-        }
-      else if(importColorLabels)
-        {
-          unsigned int index = vectColorLabels[i];
-          Color col = aColorMap(index);
-          viewer.setFillColor(col);
-        }
-      
-      if(typePrimitive=="voxel" ){
+      if (typePrimitive == "voxel")
+      {
         if (interactiveDisplayVoxCoords)
         {
-          viewer << SetName3D( name++ ) ;
+          viewer << SetName3D(name++);
         }
         viewer << Z3i::Point((int)vectVoxels.at(i)[0],
                              (int)vectVoxels.at(i)[1],
                              (int)vectVoxels.at(i)[2]);
       }
       else
-        {
-          viewer.addBall(vectVoxels.at(i), sphereRadius, sphereResolution);
-        }
-    }
-    
-    viewer << CustomColors3D(lineColor, lineColor);
-    if(drawLines)
-    {
-      for(unsigned int i=1;i< vectVoxels.size(); i++)
       {
-        viewer.addLine(vectVoxels.at(i-1), vectVoxels.at(i), lineSize);
+        viewer.addBall(vectVoxels.at(i), sphereRadius, sphereResolution);
       }
     }
-    
-    if(vectorsFileName != "")
+
+    viewer << CustomColors3D(lineColor, lineColor);
+    if (drawLines)
+    {
+      for (unsigned int i = 1; i < vectVoxels.size(); i++)
+      {
+        viewer.addLine(vectVoxels.at(i - 1), vectVoxels.at(i), lineSize);
+      }
+    }
+
+    if (vectorsFileName != "")
     {
       std::vector<Z3i::RealPoint> vectorsPt = PointListReader<Z3i::RealPoint>::getPointsFromFile(vectorsFileName);
-      if (vectorsPt.size()%2==1)
+      if (vectorsPt.size() % 2 == 1)
       {
-        trace.info()<<"Warning the two set of points doesn't contains the same number of points, some vectors will be skipped." << std::endl;
+        trace.info() << "Warning the two set of points doesn't contains the same number of points, some vectors will be skipped." << std::endl;
       }
 
       double percentage = percentageFilterVect;
-      int step = max(1, (int) (100/percentage));
-      
-      if(useUnitVector)
+      int step = max(1, (int)(100 / percentage));
+
+      if (useUnitVector)
       {
-        for(unsigned int i =0; i< std::min(vectVoxels.size(), vectorsPt.size()); i=i+2*step)
+        for (unsigned int i = 0; i < std::min(vectVoxels.size(), vectorsPt.size()); i = i + 2 * step)
         {
-          viewer.addLine(vectVoxels.at(i), vectVoxels.at(i)+vectorsPt.at(i)*constantNorm, lineSize);
+          viewer.addLine(vectVoxels.at(i), vectVoxels.at(i) + vectorsPt.at(i) * constantNorm, lineSize);
         }
       }
       else
       {
-        for(unsigned int i =0; i<vectorsPt.size()-1; i=i+2*step)
+        for (unsigned int i = 0; i < vectorsPt.size() - 1; i = i + 2 * step)
         {
-          viewer.addLine(vectorsPt.at(i),vectorsPt.at(i+1), lineSize);
+          viewer.addLine(vectorsPt.at(i), vectorsPt.at(i + 1), lineSize);
         }
       }
     }
-    if(meshName != "")
+    if (meshName != "")
     {
-      bool customColorMesh =  vectColMesh.size() == 4;
-      if(customColorMesh)
+      bool customColorMesh = vectColMesh.size() == 4;
+      if (customColorMesh)
       {
         viewer.setFillColor(DGtal::Color(vectColMesh[0], vectColMesh[1], vectColMesh[2], vectColMesh[3]));
       }
       Mesh<Z3i::RealPoint> mesh(!customColorMesh);
-      mesh << meshName ;
-      viewer << mesh;
+      mesh << meshName;
+      if (customAlphaMesh)
+      {
+        for (unsigned int j = 0; j < mesh.nbFaces(); j++)
+        {
+          auto c = mesh.getFaceColor(j);
+          mesh.setFaceColor(j, Color(c.red(), c.green(), c.blue(), customAlphaMesh));
+        }
+        viewer << mesh;
+      }
+      if (interactiveDisplayVoxCoords)
+      {
+        viewer << SetSelectCallback3D(displayCoordsCallBack, &vectVoxels, 0, vectVoxels.size() - 1);
+      }
+
+      viewer << Viewer3D<>::updateDisplay;
+      return application.exec();
     }
-    if (interactiveDisplayVoxCoords)
-    {
-      viewer << SetSelectCallback3D( displayCoordsCallBack,  &vectVoxels,  0, vectVoxels.size()-1 );
-    }
-    
-    viewer << Viewer3D<>::updateDisplay;
-    return application.exec();
   }
 }
-

--- a/visualisation/meshViewer.cpp
+++ b/visualisation/meshViewer.cpp
@@ -37,28 +37,25 @@
 #include "DGtal/helpers/StdDefs.h"
 #include "DGtal/io/readers/PointListReader.h"
 
-
 #include "CLI11.hpp"
-
 
 using namespace std;
 using namespace DGtal;
 
-
 /**
  @page meshViewer meshViewer
- 
+
  @brief Displays OFF mesh file by using QGLviewer.
- 
+
  @b Usage:   meshViewer [input]
- 
+
  @b Allowed @b options @b are :
- 
+
  @code
- 
+
  Positionals:
  1 TEXT:FILE ... REQUIRED              inputFileNames.off files (.off), or OFS file (.ofs)
- 
+
  Options:
  -h,--help                             Print this help message and exit
  -i,--input TEXT:FILE ... REQUIRED     inputFileNames.off files (.off), or OFS file (.ofs)
@@ -81,20 +78,20 @@ using namespace DGtal;
  -l,--fixLightToScene                  Fix light source to scence instead to camera
  -n,--invertNormal                     invert face normal vectors.
  -v,--drawVertex                       draw the vertex of the mesh
- 
+
  @endcode
- 
- 
+
+
  @b Example:
- 
+
  @code
  $ meshViewer bunny.off
- 
+
  @endcode
- 
+
  You should obtain such a result:
  @image html resMeshViewer.png "Resulting visualization."
-  
+
  @see
  @ref meshViewer.cpp
 
@@ -104,273 +101,331 @@ using namespace DGtal;
  * Custom Viewer3D to override KeyPressEvent method and handle new key display.
  * It also desactivate the double Rendering mode for more efficiency.
  **/
-class CustomViewer3D: public Viewer3D<>
+class CustomViewer3D : public Viewer3D<>
 {
 protected:
-  
   virtual void init()
   {
     Viewer3D<>::init();
-    Viewer3D<>::setKeyDescription ( Qt::Key_I, "Display mesh informations about #faces, #vertices" );
+    Viewer3D<>::setKeyDescription(Qt::Key_I, "Display mesh informations about #faces, #vertices");
     Viewer3D<>::setGLDoubleRenderingMode(false);
-   
   }
-  
-  virtual void keyPressEvent(QKeyEvent *e){
+
+  virtual void keyPressEvent(QKeyEvent *e)
+  {
     bool handled = false;
-    if( e->key() == Qt::Key_I)
+    if (e->key() == Qt::Key_I)
     {
-      handled=true;
+      handled = true;
       myIsDisplayingInfoMode = !myIsDisplayingInfoMode;
       stringstream ss;
       qglviewer::Vec camPos = camera()->position();
-      DGtal::Z3i::RealPoint c (camPos[0], camPos[1], camPos[2]);
-      ss << myInfoDisplay << " distance to camera: " << (c-centerMesh).norm();
-      Viewer3D<>::displayMessage(QString(myIsDisplayingInfoMode ?
-                                         ss.str().c_str() : " "), 1000000);
-      
+      DGtal::Z3i::RealPoint c(camPos[0], camPos[1], camPos[2]);
+      ss << myInfoDisplay << " distance to camera: " << (c - centerMesh).norm();
+      Viewer3D<>::displayMessage(QString(myIsDisplayingInfoMode ? ss.str().c_str() : " "), 1000000);
+
       Viewer3D<>::update();
     }
 
-    if(!handled)
+    if (!handled)
     {
       Viewer3D<>::keyPressEvent(e);
     }
   };
-  
-public: 
+
+public:
   void changeDefaultBGColor(const DGtal::Color &col)
-    {
-         myDefaultBackgroundColor = col;
-         Viewer3D<>::update();
-         Viewer3D<>::draw();
-      }
+  {
+    myDefaultBackgroundColor = col;
+    Viewer3D<>::update();
+    Viewer3D<>::draw();
+  }
   std::string myInfoDisplay = "No information loaded...";
   bool myIsDisplayingInfoMode = false;
   DGtal::Z3i::RealPoint centerMesh;
 };
 
-
-int main( int argc, char** argv )
+int main(int argc, char **argv)
 {
-  float sx {1.0};
-  float sy {1.0};
-  float sz {1.0};
-  
-  unsigned int  meshColorR {240};
-  unsigned int  meshColorG {240};
-  unsigned int  meshColorB {240};
-  unsigned int  meshColorA {255};
-  
-  unsigned int  meshColorRLine {0};
-  unsigned int  meshColorGLine {0};
-  unsigned int  meshColorBLine {0};
-  unsigned int  meshColorALine {255};
-  
-  unsigned int  sdpColorR {240};
-  unsigned int  sdpColorG {240};
-  unsigned int  sdpColorB {240};
-  unsigned int  sdpColorA {255};
-  
-  float lineWidth {1.5};
-  
-  std::vector<unsigned int > customColorMesh;
-  std::vector<unsigned int > customColorSDP;
-  std::vector<unsigned int > customLineColor;
-  std::vector<unsigned int > customBGColor;
-  std::vector<unsigned int > vectFieldIndices = {0,1,2,3,4,5};
+  float sx{1.0};
+  float sy{1.0};
+  float sz{1.0};
+
+  unsigned int meshColorR{240};
+  unsigned int meshColorG{240};
+  unsigned int meshColorB{240};
+  unsigned int meshColorA{255};
+
+  unsigned int meshColorRLine{0};
+  unsigned int meshColorGLine{0};
+  unsigned int meshColorBLine{0};
+  unsigned int meshColorALine{255};
+
+  unsigned int sdpColorR{240};
+  unsigned int sdpColorG{240};
+  unsigned int sdpColorB{240};
+  unsigned int sdpColorA{255};
+
+  float lineWidth{1.5};
+
+  std::vector<unsigned int> customColorMesh;
+  std::vector<unsigned int> customColorSDP;
+  std::vector<unsigned int> customLineColor;
+  std::vector<unsigned int> customBGColor;
+  std::vector<unsigned int> customAlphaMesh;
+  std::vector<unsigned int> vectFieldIndices = {0, 1, 2, 3, 4, 5};
   std::string displayVectorField;
-  
+
   std::string snapshotFile;
   std::string filenameSDP;
-  double ballRadius {0.5};
-  bool invertNormal {false};
-  bool drawVertex {false};
-  bool useLastCamSet {false};
-  bool fixLightToScene {false};
-  float ambiantLight {0.0};
-  std::vector<unsigned int> customAlphaMesh;
-  
+  double ballRadius{0.5};
+  bool invertNormal{false};
+  bool drawVertex{false};
+  bool useLastCamSet{false};
+  bool fixLightToScene{false};
+  float ambiantLight{0.0};
+
   // parse command line using CLI ----------------------------------------------
   CLI::App app;
   std::vector<std::string> inputFileNames;
-  std::string outputFileName {"result.raw"};
+  std::string outputFileName{"result.raw"};
   app.description("Display OFF mesh file by using QGLviewer");
-  app.add_option("-i,--input,1", inputFileNames, "inputFileNames.off files (.off), or OFS file (.ofs)" )
-  ->check(CLI::ExistingFile)
-  ->required();
+  app.add_option("-i,--input,1", inputFileNames, "inputFileNames.off files (.off), or OFS file (.ofs)")
+      ->check(CLI::ExistingFile)
+      ->required();
   app.add_option("-x,--scaleX", sx, "set the scale value in the X direction (default 1.0)");
   app.add_option("-y,--scaleY", sy, "set the scale value in the y direction (default 1.0)");
   app.add_option("-z,--scaleZ", sz, "set the scale value in the z direction (default 1.0)");
   app.add_option("--minLineWidth", lineWidth, "set the min line width of the mesh faces (default 1.5)", true);
   app.add_option("--customColorMesh", customColorMesh, "set the R, G, B, A components of the colors of the mesh faces and eventually the color R, G, B, A of the mesh edge lines (set by default to black).");
-  app.add_option("--customAlphaMesh", customAlphaMesh, "set the alpha components of the colors of the mesh faces (can be applied for each mesh).");
-  
-  app.add_option("--customColorSDP", customColorSDP, "set the R, G, B, A components of the colors of  the sdp view")
-  ->expected(4);
+  app.add_option("--customAlphaMesh", customAlphaMesh, "set the alpha(A) components of the colors of the mesh faces (can be applied for each mesh).");
+  app.add_option("--customColorSDP", customColorSDP, "set the R, G, B, A components of the colors of the sdp view")
+      ->expected(4);
   app.add_option("--displayVectorField,-f", displayVectorField, "display a vector field from a simple sdp file (two points per line)");
-  app.add_option("--vectorFieldIndex", vectFieldIndices, "specify special indices for the two point coordinates (instead usinf the default indices: 0 1, 2, 3, 4, 5)" )
-  ->expected(6);
+  app.add_option("--vectorFieldIndex", vectFieldIndices, "specify special indices for the two point coordinates (instead usinf the default indices: 0 1, 2, 3, 4, 5)")
+      ->expected(6);
   app.add_option("--customLineColor", customLineColor, "set the R, G, B components of the colors of the lines displayed from the --displayVectorField option (red by default).")
-  ->expected(4);
+      ->expected(4);
   app.add_option("--SDPradius", ballRadius, "change the ball radius to display a set of discrete points (used with displaySDP option)", true);
-  app.add_option("--displaySDP,-s", filenameSDP,  "add the display of a set of discrete points as ball of radius 0.5.");
-  app.add_option("--addAmbientLight,-A", ambiantLight, "add an ambient light for better display (between 0 and 1)." );
+  app.add_option("--displaySDP,-s", filenameSDP, "add the display of a set of discrete points as ball of radius 0.5.");
+  app.add_option("--addAmbientLight,-A", ambiantLight, "add an ambient light for better display (between 0 and 1).");
   app.add_option("--customBGColor,-b", customBGColor, "set the R, G, B components of the colors of the background color.")
-    ->expected(3);
+      ->expected(3);
   app.add_option("--doSnapShotAndExit,-d", snapshotFile, "save display snapshot into file. Notes that the camera setting is set by default according the last saved configuration (use SHIFT+Key_M to save current camera setting in the Viewer3D). If the camera setting was not saved it will use the default camera setting.");
   app.add_flag("--useLastCameraSetting,-c", useLastCamSet, "use the last camera setting of the user (i.e if a .qglviewer.xml file is present in the current directory)");
   app.add_flag("--fixLightToScene,-l", fixLightToScene, "Fix light source to scence instead to camera");
   app.add_flag("--invertNormal,-n", invertNormal, "invert face normal vectors.");
   app.add_flag("--drawVertex,-v", drawVertex, "draw the vertex of the mesh");
 
-  
   app.get_formatter()->column_width(40);
   CLI11_PARSE(app, argc, argv);
   // END parse command line using CLI ----------------------------------------------
-  
-  
-  
+
   DGtal::Color vFieldLineColor = DGtal::Color::Red;
-  if( customLineColor.size() == 4)
+  if (customLineColor.size() == 4)
   {
     vFieldLineColor.setRGBi(customLineColor[0], customLineColor[1], customLineColor[2], 255);
   }
-  
-  if( customColorMesh.size() != 0 )
+
+  if (customColorMesh.size() != 0)
   {
-    if(customColorMesh.size()<4 )
+    if (customColorMesh.size() < 4)
     {
-      trace.error() << "colors specification should contain R,G,B and Alpha values"<< std::endl;
+      trace.error() << "colors specification should contain R,G,B and Alpha values" << std::endl;
     }
-      
   }
-  
-  if(customColorSDP.size() == 4)
+
+  if (customColorSDP.size() == 4)
   {
     sdpColorR = customColorSDP[0];
     sdpColorG = customColorSDP[1];
     sdpColorB = customColorSDP[2];
     sdpColorA = customColorSDP[3];
   }
-  
-  QApplication application(argc,argv);
+
+  QApplication application(argc, argv);
   CustomViewer3D viewer;
-  if(snapshotFile != "")
+  if (snapshotFile != "")
   {
     viewer.setSnapshotFileName(QString(snapshotFile.c_str()));
   }
-  
+
   std::stringstream title;
-  title  << "Simple Mesh Viewer: " << inputFileNames[0];
+  title << "Simple Mesh Viewer: " << inputFileNames[0];
   viewer.setWindowTitle(title.str().c_str());
   viewer.show();
   viewer.myGLLineMinWidth = lineWidth;
   viewer.setGLScale(sx, sy, sz);
-  if (customBGColor.size() == 3){
-        viewer.changeDefaultBGColor(DGtal::Color(customBGColor[0],
-                                                 customBGColor[1],
-                                                 customBGColor[2], 255));
-  }
-  if(ambiantLight != 0.0)
+  if (customBGColor.size() == 3)
   {
-    GLfloat lightAmbientCoeffs [4] = {ambiantLight,ambiantLight, ambiantLight, 1.0f};
+    viewer.changeDefaultBGColor(DGtal::Color(customBGColor[0],
+                                             customBGColor[1],
+                                             customBGColor[2], 255));
+  }
+  if (ambiantLight != 0.0)
+  {
+    GLfloat lightAmbientCoeffs[4] = {ambiantLight, ambiantLight, ambiantLight, 1.0f};
     viewer.setGLLightAmbientCoefficients(lightAmbientCoeffs);
   }
-  
+
   trace.info() << "Importing mesh... ";
-  
-  std::vector<Mesh<DGtal::Z3i::RealPoint> >  vectMesh;
-  for(unsigned int i = 0; i< inputFileNames.size(); i++)
+
+  std::vector<Mesh<DGtal::Z3i::RealPoint>> vectMesh;
+  for (unsigned int i = 0; i < inputFileNames.size(); i++)
   {
     Mesh<DGtal::Z3i::RealPoint> aMesh(customColorMesh.size() != 4 && customColorMesh.size() != 8);
     aMesh << inputFileNames[i];
-      // for obj mesh by default the mesh color face are not necessary uniform.
-      if (aMesh.isStoringFaceColors() && customColorMesh.size() >= 4 ){
-          if ( i*8 < customColorMesh.size() ) {meshColorR = customColorMesh[i*8];}
-          if ( i*8+1< customColorMesh.size() ) {meshColorG = customColorMesh[i*8+1];}
-          if ( i*8+2 < customColorMesh.size() ) {meshColorB = customColorMesh[i*8+2];}
-          if ( i*8+3 < customColorMesh.size() ) {meshColorA = customColorMesh[i*8+3];}
-          for (unsigned int j = 0; j < aMesh.nbFaces(); j++){
-              aMesh.setFaceColor(j, Color(meshColorR, meshColorG, meshColorB, meshColorA));
-          }
-      }else if (customAlphaMesh.size() > 0 ) {
-          for (unsigned int j = 0; j < aMesh.nbFaces(); j++){
-	    auto c = aMesh.getFaceColor(j);
-            aMesh.setFaceColor(j, Color(c.red(), c.green(), c.blue(), customAlphaMesh.at(i<customAlphaMesh.size() ? i: 0)));
-          }
-	
+    // for obj mesh by default the mesh color face are not necessary uniform.
+    if (aMesh.isStoringFaceColors() && customColorMesh.size() >= 4)
+    {
+      if (i * 8 < customColorMesh.size())
+      {
+        meshColorR = customColorMesh[i * 8];
       }
-      
+      if (i * 8 + 1 < customColorMesh.size())
+      {
+        meshColorG = customColorMesh[i * 8 + 1];
+      }
+      if (i * 8 + 2 < customColorMesh.size())
+      {
+        meshColorB = customColorMesh[i * 8 + 2];
+      }
+      if (i * 8 + 3 < customColorMesh.size())
+      {
+        meshColorA = customColorMesh[i * 8 + 3];
+      }
+      for (unsigned int j = 0; j < aMesh.nbFaces(); j++)
+      {
+        aMesh.setFaceColor(j, Color(meshColorR, meshColorG, meshColorB, meshColorA));
+      }
+    }
+    else if (customAlphaMesh.size() > 0)
+    {
+      for (unsigned int j = 0; j < aMesh.nbFaces(); j++)
+      {
+        auto c = aMesh.getFaceColor(j);
+        aMesh.setFaceColor(j, Color(c.red(), c.green(), c.blue(), customAlphaMesh.at(i < customAlphaMesh.size() ? i : 0)));
+      }
+    }
+
     vectMesh.push_back(aMesh);
   }
   DGtal::Z3i::RealPoint centerMeshes;
-  unsigned int tot=0;
-  for(const auto & m: vectMesh)
+  unsigned int tot = 0;
+  for (const auto &m : vectMesh)
   {
-    for( auto p = m.vertexBegin(); p!=m.vertexEnd(); ++p)
+    for (auto p = m.vertexBegin(); p != m.vertexEnd(); ++p)
       centerMeshes += *p;
-    tot+=m.nbVertex();
+    tot += m.nbVertex();
   }
   centerMeshes /= tot;
   viewer.centerMesh = centerMeshes;
-  bool import = vectMesh.size()==inputFileNames.size();
-  if(!import)
+  bool import = vectMesh.size() == inputFileNames.size();
+  if (!import)
   {
     trace.info() << "File import failed. " << std::endl;
     return 0;
   }
-  
-  trace.info() << "[done]. "<< std::endl;
-  if(filenameSDP != "")
+
+  trace.info() << "[done]. " << std::endl;
+  if (filenameSDP != "")
   {
-    vector<Z3i::RealPoint> vectPoints;
-    vectPoints = PointListReader<Z3i::RealPoint>::getPointsFromFile(filenameSDP);
-    viewer << CustomColors3D(Color(sdpColorR, sdpColorG, sdpColorB, sdpColorA),
-                             Color(sdpColorR, sdpColorG, sdpColorB, sdpColorA));
-    for(unsigned int i=0;i< vectPoints.size(); i++){
-      viewer.addBall(vectPoints.at(i), ballRadius);
+    if (customAlphaMesh.size() > 0)
+    {
+      trace.info() << "New meshViewer" << std::endl;
+      auto vOrigins = PointListReader<PointVector<1, DGtal::int32_t>>::getPolygonsFromFile(filenameSDP);
+      viewer << CustomColors3D(Color(sdpColorR, sdpColorG, sdpColorB, sdpColorA),
+                               Color(sdpColorR, sdpColorG, sdpColorB, sdpColorA));
+      for (auto l : vOrigins)
+      {
+        DGtal::Z3i::Point pt(l[0][0], l[1][0], l[2][0]);
+        DGtal::Color cl(l[3][0], l[4][0], l[5][0], sdpColorA);
+        viewer.setFillColor(cl);
+        viewer.addBall(pt, ballRadius);
+      }
+    }
+    else
+    {
+      vector<Z3i::RealPoint> vectPoints;
+      vectPoints = PointListReader<Z3i::RealPoint>::getPointsFromFile(filenameSDP);
+      viewer << CustomColors3D(Color(sdpColorR, sdpColorG, sdpColorB, sdpColorA),
+                               Color(sdpColorR, sdpColorG, sdpColorB, sdpColorA));
+      for (unsigned int i = 0; i < vectPoints.size(); i++)
+      {
+        viewer.addBall(vectPoints.at(i), ballRadius);
+      }
     }
   }
-  if(invertNormal)
+  if (invertNormal)
   {
-    for(unsigned int i=0; i<vectMesh.size(); i++){
+    for (unsigned int i = 0; i < vectMesh.size(); i++)
+    {
       vectMesh[i].invertVertexFaceOrder();
     }
   }
-  
-   for(unsigned int i=0; i<vectMesh.size(); i++){
-       if ( i*8 < customColorMesh.size() ) {meshColorR = customColorMesh[i*8];}
-       if ( i*8+1< customColorMesh.size() ) {meshColorG = customColorMesh[i*8+1];}
-       if ( i*8+2 < customColorMesh.size() ) {meshColorB = customColorMesh[i*8+2];}
-       if ( i*8+3 < customColorMesh.size() ) {meshColorA = customColorMesh[i*8+3];}
-       if ( i*8+4 < customColorMesh.size() ) {meshColorALine = customColorMesh[i*8+4];}
-       if ( i*8+5< customColorMesh.size() ) {meshColorBLine = customColorMesh[i*8+5];}
-       if ( i*8+6 < customColorMesh.size() ) {meshColorRLine = customColorMesh[i*8+6];}
-       if ( i*8+7 < customColorMesh.size() ) {meshColorALine = customColorMesh[i*8+7];}
 
-       viewer << CustomColors3D(Color(meshColorRLine, meshColorGLine, meshColorBLine,
-                                      meshColorALine),
-                                Color(meshColorR, meshColorG, meshColorB, meshColorA));
+  for (unsigned int i = 0; i < vectMesh.size(); i++)
+  {
+    if (i * 8 < customColorMesh.size())
+    {
+      meshColorR = customColorMesh[i * 8];
+    }
+    if (i * 8 + 1 < customColorMesh.size())
+    {
+      meshColorG = customColorMesh[i * 8 + 1];
+    }
+    if (i * 8 + 2 < customColorMesh.size())
+    {
+      meshColorB = customColorMesh[i * 8 + 2];
+    }
+    if (i * 8 + 3 < customColorMesh.size())
+    {
+      meshColorA = customColorMesh[i * 8 + 3];
+    }
+    if (i * 8 + 4 < customColorMesh.size())
+    {
+      meshColorALine = customColorMesh[i * 8 + 4];
+    }
+    if (i * 8 + 5 < customColorMesh.size())
+    {
+      meshColorBLine = customColorMesh[i * 8 + 5];
+    }
+    if (i * 8 + 6 < customColorMesh.size())
+    {
+      meshColorRLine = customColorMesh[i * 8 + 6];
+    }
+    if (i * 8 + 7 < customColorMesh.size())
+    {
+      meshColorALine = customColorMesh[i * 8 + 7];
+    }
 
-      viewer << vectMesh[i];
+    viewer << CustomColors3D(Color(meshColorRLine, meshColorGLine, meshColorBLine,
+                                   meshColorALine),
+                             Color(meshColorR, meshColorG, meshColorB, meshColorA));
+
+    viewer << vectMesh[i];
   }
-  
-  if(drawVertex){
-    for(unsigned int i=0; i<vectMesh.size(); i++){
-      for( Mesh<DGtal::Z3i::RealPoint>::VertexStorage::const_iterator it = vectMesh[i].vertexBegin();
-          it!=vectMesh[i].vertexEnd(); ++it){
+
+  if (drawVertex)
+  {
+    for (unsigned int i = 0; i < vectMesh.size(); i++)
+    {
+      for (Mesh<DGtal::Z3i::RealPoint>::VertexStorage::const_iterator it = vectMesh[i].vertexBegin();
+           it != vectMesh[i].vertexEnd(); ++it)
+      {
         DGtal::Z3i::Point pt;
-        pt[0]=(*it)[0]; pt[1]=(*it)[1]; pt[2]=(*it)[2];
+        pt[0] = (*it)[0];
+        pt[1] = (*it)[1];
+        pt[2] = (*it)[2];
         viewer << pt;
       }
     }
   }
-  
+
   if (displayVectorField != "")
   {
-    std::vector<unsigned int > vectFieldIndices1 = {vectFieldIndices[0],vectFieldIndices[1], vectFieldIndices[2]};
-    std::vector<unsigned int > vectFieldIndices2 = {vectFieldIndices[3],vectFieldIndices[4], vectFieldIndices[5]};
+    std::vector<unsigned int> vectFieldIndices1 = {vectFieldIndices[0], vectFieldIndices[1], vectFieldIndices[2]};
+    std::vector<unsigned int> vectFieldIndices2 = {vectFieldIndices[3], vectFieldIndices[4], vectFieldIndices[5]};
     std::vector<DGtal::Z3i::RealPoint> vectPt1 = PointListReader<DGtal::Z3i::RealPoint>::getPointsFromFile(displayVectorField, vectFieldIndices1);
     std::vector<DGtal::Z3i::RealPoint> vectPt2 = PointListReader<DGtal::Z3i::RealPoint>::getPointsFromFile(displayVectorField, vectFieldIndices2);
     viewer.createNewLineList();
@@ -382,44 +437,44 @@ int main( int argc, char** argv )
   }
   unsigned int nbVertex = 0;
   unsigned int nbFaces = 0;
-  for(auto const &m:  vectMesh)
+  for (auto const &m : vectMesh)
   {
     nbVertex += m.nbVertex();
-    nbFaces +=m.nbFaces();
+    nbFaces += m.nbFaces();
   }
   stringstream ss;
-  ss << "# faces: " << std::fixed << nbFaces << "    #vertex: " <<  nbVertex ;
+  ss << "# faces: " << std::fixed << nbFaces << "    #vertex: " << nbVertex;
   viewer.myInfoDisplay = ss.str();
-  viewer  << CustomViewer3D::updateDisplay;
+  viewer << CustomViewer3D::updateDisplay;
   if (fixLightToScene)
   {
-      viewer.setLightModeFixToCamera(false, false);
+    viewer.setLightModeFixToCamera(false, false);
   }
 
   if (useLastCamSet)
   {
-      viewer.restoreStateFromFile();
+    viewer.restoreStateFromFile();
   }
   else
   {
-      // useful in non interactive case in order to retain the default camera settings (that are not saved in case of process kill).
-      viewer.saveStateToFile();
+    // useful in non interactive case in order to retain the default camera settings (that are not saved in case of process kill).
+    viewer.saveStateToFile();
   }
   // First display transparency improve
   viewer.sortTriangleFromCamera();
   viewer.sortQuadFromCamera();
   viewer.sortSurfelFromCamera();
   viewer.sortPolygonFromCamera();
-  viewer  << CustomViewer3D::updateDisplay;
-  
-  if(snapshotFile != "" )
+  viewer << CustomViewer3D::updateDisplay;
+
+  if (snapshotFile != "")
   {
     // Recover mesh position
     viewer.restoreStateFromFile();
     viewer.saveSnapshot(QString(snapshotFile.c_str()), true);
     return 0;
   }
-  trace.info() << "[display ready]"<< std::endl;
+  trace.info() << "[display ready]" << std::endl;
 
   return application.exec();
 }


### PR DESCRIPTION
*Thanks a lot for contributing to DGtalTools, before submitting your PR, please fill up the description and make sure that all checkboxes are checked.*

# PR Description

* Add colored SDP option in meshViewer when input texts are an alpha mesh and a colored SDP
* Add alpha mesh option in 3dSDPViewer

# Checklist

- [x] Doxygen documentation of the code completed (classes, methods, types, members...).
- [x] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [x] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Github Actions C.I. will fail).
- [ ] All continuous integration tests pass (Github Actions).
