### PR TITLE
Remove preprocessor fix stbImage MSVC link error

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # DGtalTools 1.4 (beta)
 
+- *build*
+  - Remove STBimage preprocessor instruction used to fix MVSC that is 
+    no more usefull since DGtal PR [175](https://github.com/DGtal-team/DGtal/pull/1715) 
+    (Bertrand Kerautret [#458](https://github.com/DGtal-team/DGtalTools/pull/458))
+
+
 - *visualisation*
   - meshViewer: new options to change the default background color, to
     load camera settings at startup, to change at startup the light

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,7 @@
 - *build*
   - Remove STBimage preprocessor instruction used to fix MVSC that is 
     no more usefull since DGtal PR [175](https://github.com/DGtal-team/DGtal/pull/1715) 
-    (Bertrand Kerautret [#458](https://github.com/DGtal-team/DGtalTools/pull/458))
+    (Bertrand Kerautret [#459](https://github.com/DGtal-team/DGtalTools/pull/459))
 
 
 - *visualisation*

--- a/visualisation/volscope.cpp
+++ b/visualisation/volscope.cpp
@@ -26,7 +26,7 @@
  *
  * This file is part of the DGtal library.
  */
-#define NO_ADD_STBIMAGE_IMPLEMENT //To avoid duplicated linking errors (like LNK2005 in MSVC)
+
 #include <vector>
 #include <array>
 


### PR DESCRIPTION
# PR Description
 Remove STBimage preprocessor instruction used to fix MVSC that is no more usefull since DGtal PR [175](https://github.com/DGtal-team/DGtal/pull/1715) 

# Checklist

- [x] Doxygen documentation of the code completed (classes, methods, types, members...).
- [x] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [x] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Github Actions C.I. will fail).
- [x] All continuous integration tests pass (Github Actions).
