### PR TITLE
Adapt 3dHeightMapViewer from polyscope

### DIFF
--- a/visualisation/3dHeightMapViewer.cpp
+++ b/visualisation/3dHeightMapViewer.cpp
@@ -38,12 +38,17 @@
 #include <DGtal/images/ImageContainerBySTLVector.h>
 
 #include "DGtal/io/Color.h"
-
+#include "DGtal/images/ImageLinearCellEmbedder.h"
+#include "DGtal/images/ImageSelector.h"
 #include <DGtal/base/ConstAlias.h>
 #include <DGtal/kernel/BasicPointFunctors.h>
 #include <DGtal/topology/helpers/Surfaces.h>
 #include <DGtal/io/colormaps/GradientColorMap.h>
 #include <DGtal/io/colormaps/GrayscaleColorMap.h>
+#include <DGtal/topology/SetOfSurfels.h>
+#include <DGtal/topology/DigitalSurface.h>
+#include "DGtal/shapes/TriangulatedSurface.h"
+#include "DGtal/shapes/MeshHelpers.h"
 
 using namespace std;
 using namespace DGtal;
@@ -57,143 +62,179 @@ using namespace Z3i;
  @page Doc3dHeightMapViewer 3dHeightMapViewer
  
  @brief  Displays 2D image as heightmap by using QGLviewer.
-
+ 
  @b Usage:  3dImageViewer [options] input
  
-
+ 
  @b Allowed @b options @b are :
  
  @code
-
+ 
  Positionals:
-   1 TEXT:FILE REQUIRED                  2d input image representing the height map (given as grayscape image cast into 8 bits).
-
+ 1 TEXT:FILE REQUIRED                  2d input image representing the height map (given as grayscape image cast into 8 bits).
+ 
  Options:
-   -h,--help                             Print this help message and exit
-   -i,--input TEXT:FILE REQUIRED         2d input image representing the height map (given as grayscape image cast into 8 bits).
-   -s,--scale FLOAT                      set the scale of the maximal level. (default 1.0)
-   -c,--colorMap                         define the heightmap color with a pre-defined colormap (GradientColorMap)
-   -t,--colorTextureImage TEXT           define the heightmap color from a given color image (32 bits image).
-
+ -h,--help                             Print this help message and exit
+ -i,--input TEXT:FILE REQUIRED         2d input image representing the height map (given as grayscape image cast into 8 bits).
+ -s,--scale FLOAT                      set the scale of the maximal level. (default 1.0)
+ -c,--colorMap                         define the heightmap color with a pre-defined colormap (GradientColorMap)
+ -t,--colorTextureImage TEXT           define the heightmap color from a given color image (32 bits image).
+ 
  @endcode
-
-
- @b Example: 
+ 
+ 
+ @b Example:
  
  @code
  $ visualisation/3dHeightMapViewer ${DGtal}/examples/samples/church.pgm -s 0.2
- @endcode 
-
+ @endcode
+ 
  You should obtain such a result:
-
+ 
  @image html res3dHeightMapViewer.png "resulting heightmap visualisation."
  
-
+ 
  @see
  @ref 3dHeightMapViewer.cpp
-
+ 
  */
 
 // Defining a Helper to get the 3D point functor from an 2DImage
 template<typename TImage2D, typename TPoint3D >
 struct Image3DPredicatFrom2DImage{
-  typedef  TPoint3D Point3D;
-  /**
-   *  Construct the predicat given a 2D Image
-   **/
-  Image3DPredicatFrom2DImage(DGtal::ConstAlias<TImage2D> anImage, double aScale):myImageRef(anImage),
-                                                                                 myScale(aScale){
-  }
-  inline
-  bool operator()(const Point3D &aPoint)  const {
-    functors::Projector<SpaceND<2, typename TImage2D::Integer> > projXY;
-    return  (*myImageRef)(projXY(aPoint))*myScale >= aPoint[2];
-  }
-  CountedConstPtrOrConstPtr<TImage2D> myImageRef;
-  double myScale;
+    typedef  TPoint3D Point3D;
+    /**
+     *  Construct the predicat given a 2D Image
+     **/
+    Image3DPredicatFrom2DImage(DGtal::ConstAlias<TImage2D> anImage, double aScale):myImageRef(anImage),
+    myScale(aScale){
+    }
+    inline
+    bool operator()(const Point3D &aPoint)  const {
+        functors::Projector<SpaceND<2, typename TImage2D::Integer> > projXY;
+        return  (*myImageRef)(projXY(aPoint))*myScale >= aPoint[2];
+    }
+    CountedConstPtrOrConstPtr<TImage2D> myImageRef;
+    double myScale;
 };
 
 
 
 
-
+typedef ImageSelector < Domain, int>::Type Image;
 
 
 
 int main( int argc, char** argv )
 {
-  
-  // parse command line using CLI ----------------------------------------------
-  CLI::App app;
-  std::string inputFileName;
-  double scale {1.0};
-  bool colorMap {false};
-  std::string colorTextureImage;
-  app.description("Displays 2D image as heightmap by using QGLviewer.\n Exemple of use:  visualisation/3dHeightMapViewer  ${DGtal}/examples/samples/church.pgm -s 0.2");
-  
-  app.add_option("-i,--input,1", inputFileName, "2d input image representing the height map (given as grayscape image cast into 8 bits)." )
-  ->required()
-  ->check(CLI::ExistingFile);
-  app.add_option("--scale,-s",scale,  "set the scale of the maximal level. (default 1.0)");
-  app.add_flag("--colorMap,-c", colorMap, "define the heightmap color with a pre-defined colormap (GradientColorMap)");
-  app.add_option("--colorTextureImage,-t", colorTextureImage,  "define the heightmap color from a given color image (32 bits image).");
-  
-  
-  
-  app.get_formatter()->column_width(40);
-  CLI11_PARSE(app, argc, argv);
-  // END parse command line using CLI ----------------------------------------------
-
-  
-  typedef DGtal::ImageContainerBySTLVector<Z2i::Domain, unsigned char> Image2DG ;
-  typedef DGtal::ImageContainerBySTLVector<Z2i::Domain, unsigned int> Image2DCol ;
-
-  Image2DG image = GenericReader<Image2DG>::import( inputFileName );
-  Image2DCol imageTexture(image.domain());
-  int maxHeight = (int)(std::numeric_limits<Image2DG::Value>::max()*scale);
-  trace.info()<< "Max height from scale:" << maxHeight << std::endl;
-
-  if(colorTextureImage != ""){
-    imageTexture =  GenericReader<Image2DCol>::import( colorTextureImage );
-  }
-
-  Z2i::RealPoint plow (image.domain().lowerBound()[0]-0.5,
-                       image.domain().lowerBound()[1]-0.5);
-  
-  Z2i::RealPoint pup (image.domain().upperBound()[0]+0.5,
-                      image.domain().upperBound()[1]+0.5);
-  
-  PolyscopeViewer viewer;
-
-
-  KSpace K;
-  K.init(Z3i::Point(0,0,0),Z3i::Point(image.domain().upperBound()[0], image.domain().upperBound()[1], maxHeight+1), true);
-  std::set<KSpace::SCell> boundVect;
-  Image3DPredicatFrom2DImage<Image2DG, Z3i::Point> image3Dpredicate(image, scale);
-  trace.info() << "Constructing boundary... ";
-  Surfaces<KSpace>::sMakeBoundary (boundVect, K, image3Dpredicate, Z3i::Point(0,0,0),
-                                   Z3i::Point(image.domain().upperBound()[0], image.domain().upperBound()[1], maxHeight+1));
-  trace.info() << "[done]"<< std::endl;
-
-  viewer.drawAsSimplified();
-  GradientColorMap<Image2DG::Value,CMAP_JET>  gradientShade( 0, std::numeric_limits<Image2DG::Value>::max());
-  GrayscaleColorMap<Image2DG::Value>  grayShade(0, std::numeric_limits<Image2DG::Value>::max());
-
-
-  for(std::set<KSpace::SCell>::const_iterator it = boundVect.begin();
-      it!= boundVect.end(); it++){
-    Z3i::Point pt = K.sCoords(K.sDirectIncident( *it, 2 ));
-    functors::Projector<SpaceND<2,int> > proj;
-    Image2DG::Value val = image(proj(pt));
-
-    if(!colorMap && colorTextureImage != ""){
-      viewer << WithQuantity(*it, "color", Color(imageTexture(proj(pt))));
-    } else {
-      viewer << WithQuantity(*it, "value", val);
+    
+    // parse command line using CLI ----------------------------------------------
+    CLI::App app;
+    std::string inputFileName;
+    double scale {1.0};
+    bool colorMap {false};
+    std::string colorTextureImage;
+    app.description("Displays 2D image as heightmap by using QGLviewer.\n Exemple of use:  visualisation/3dHeightMapViewer  ${DGtal}/examples/samples/church.pgm -s 0.2");
+    
+    app.add_option("-i,--input,1", inputFileName, "2d input image representing the height map (given as grayscape image cast into 8 bits)." )
+    ->required()
+    ->check(CLI::ExistingFile);
+    app.add_option("--scale,-s",scale,  "set the scale of the maximal level. (default 1.0)");
+    app.add_flag("--colorMap,-c", colorMap, "define the heightmap color with a pre-defined colormap (GradientColorMap)");
+    app.add_option("--colorTextureImage,-t", colorTextureImage,  "define the heightmap color from a given color image (32 bits image).");
+    
+    
+    
+    app.get_formatter()->column_width(40);
+    CLI11_PARSE(app, argc, argv);
+    // END parse command line using CLI ----------------------------------------------
+    
+    
+    typedef DGtal::ImageContainerBySTLVector<Z2i::Domain, unsigned char> Image2DG ;
+    typedef DGtal::ImageContainerBySTLVector<Z2i::Domain, unsigned int> Image2DCol ;
+    
+    Image2DG image = GenericReader<Image2DG>::import( inputFileName );
+    Image2DCol imageTexture(image.domain());
+    int maxHeight = (int)(std::numeric_limits<Image2DG::Value>::max()*scale);
+    trace.info()<< "Max height from scale:" << maxHeight << std::endl;
+    
+    if(colorTextureImage != ""){
+        imageTexture =  GenericReader<Image2DCol>::import( colorTextureImage );
     }
-    viewer << *it;
-  }
+    
+    Z2i::RealPoint plow (image.domain().lowerBound()[0]-0.5,
+                         image.domain().lowerBound()[1]-0.5);
+    
+    Z2i::RealPoint pup (image.domain().upperBound()[0]+0.5,
+                        image.domain().upperBound()[1]+0.5);
+    
+    PolyscopeViewer viewer;
+    bool intAdjacency = true;
+    
+    typedef SurfelAdjacency<KSpace::dimension> MySurfelAdjacency;
+    typedef KSpace::SurfelSet SurfelSet;
+    typedef SetOfSurfels< KSpace, SurfelSet > MySetOfSurfels;
+    typedef DigitalSurface< MySetOfSurfels > MyDigitalSurface;
+    
+    typedef SurfelAdjacency<KSpace::dimension> MySurfelAdjacency;
+    MySurfelAdjacency surfAdj( intAdjacency ); // interior in all directions.
+    
+    
+    KSpace K;
+    K.init(Z3i::Point(0,0,0),Z3i::Point(image.domain().upperBound()[0], image.domain().upperBound()[1], maxHeight+1), true);
+    SurfelSet boundVect;
+    Image3DPredicatFrom2DImage<Image2DG, Z3i::Point> image3Dpredicate(image, scale);
+    trace.info() << "Constructing boundary... ";
+    MySetOfSurfels theSetOfSurfels( K, surfAdj );
+    
+    Surfaces<KSpace>::sMakeBoundary( theSetOfSurfels.surfelSet(),
+                                    K, image3Dpredicate, Z3i::Point(0,0,0),
+                                    Z3i::Point(image.domain().upperBound()[0], image.domain().upperBound()[1], maxHeight+1) );
+    trace.info() << "[done]"<< std::endl;
+    
+    MyDigitalSurface digSurf( theSetOfSurfels );
+    trace.info() << "Digital surface has " << digSurf.size() << " surfels."
+    << std::endl;
+    
+    trace.beginBlock( "Making triangulated surface. " );
+    typedef CanonicEmbedder< Space >                                  TrivialEmbedder;
+    typedef ImageLinearCellEmbedder< KSpace,Image , TrivialEmbedder > CellEmbedder;
+    typedef CellEmbedder::Value                                       RealPoint;
+    typedef TriangulatedSurface< RealPoint >                          TriMesh;
+    typedef Mesh< RealPoint >                                         ViewMesh;
+    typedef std::map< MyDigitalSurface::Vertex, TriMesh::Index >      VertexMap;
+    TriMesh         trimesh;
+    ViewMesh        viewmesh;
+    TrivialEmbedder trivialEmbedder;
+    CellEmbedder    cellEmbedder;
+    Image::Domain d (Z3i::Point(0,0,0),Z3i::Point(image.domain().upperBound()[0], image.domain().upperBound()[1], maxHeight+1));
+    Image imageE(d);
+    for (auto p : imageE.domain()){
+        imageE.setValue(p, image3Dpredicate(p));
+    }
+    cellEmbedder.init(K, imageE, trivialEmbedder, 0);
+    VertexMap vmap;
+    MeshHelpers::digitalSurface2DualTriangulatedSurface
+    ( digSurf, cellEmbedder, trimesh, vmap );
+    MeshHelpers::triangulatedSurface2Mesh( trimesh, viewmesh );
+    trace.info() << "Mesh has " << viewmesh.nbVertex()
+    << " vertices and " << viewmesh.nbFaces() << " faces." << std::endl;
+    trace.endBlock();
+    for (unsigned int i = 0; i < viewmesh.nbFaces(); i++){
+        auto b =  viewmesh.getFaceBarycenter(i);
+        auto bp = Z2i::Point(b[0], b[1]);
+        if (image.domain().isInside(bp)){
+            if (colorTextureImage == "")
+                viewmesh.setFaceColor(i, DGtal::Color(image(bp)));
+            else
+                viewmesh.setFaceColor(i, DGtal::Color(imageTexture(bp)));
 
-  viewer.show();
-  return 0;
+        }
+    }
+    viewer.drawColor(Color(150,0,0,254));
+    viewer << viewmesh;
+    
+    viewer.show();
+    return 0;
 }
+

--- a/visualisation/3dHeightMapViewer.cpp
+++ b/visualisation/3dHeightMapViewer.cpp
@@ -167,13 +167,17 @@ void callbackFaceID() {
     }
     if (ImGui::IsKeyPressed(ImGuiKey_UpArrow))
     {
-        posSliceZ++;
-        updateSlice("sliceplane", imagePtInf, imagePtSup);
+        if (posSliceZ <= maxPosSliceZ) {
+            posSliceZ++;
+            updateSlice("sliceplane", imagePtInf, imagePtSup);
+        }
     }
     if (ImGui::IsKeyPressed(ImGuiKey_DownArrow))
     {
-        posSliceZ--;
-        updateSlice("sliceplane", imagePtInf, imagePtSup);
+        if (posSliceZ > 0) {
+            posSliceZ--;
+            updateSlice("sliceplane", imagePtInf, imagePtSup);
+        }
     }
     
     
@@ -206,6 +210,8 @@ void callbackFaceID() {
         ImGui::Separator();
         ImGui::Text("Keys:");
             ImGui::Text("UP/DOWN arrow : Move slice");
+            ImGui::Text("W: Hide/Show this panel");
+
         ImGui::End();
     }
   
@@ -256,7 +262,7 @@ int main( int argc, char** argv )
     
     Image2DG image = GenericReader<Image2DG>::import( inputFileName );
     Image2DCol imageTexture(image.domain());
-    int maxHeight = (int)(std::numeric_limits<Image2DG::Value>::max()*scale);
+    Image2DG::Value  maxHeight =   *std::max_element(image.begin(), image.end()) * scale;
     trace.info()<< "Max height from scale:" << maxHeight << std::endl;
     GradientColorMap<Image2DG::Value,CMAP_JET>  gradientShade( 0, std::numeric_limits<Image2DG::Value>::max());
     GrayscaleColorMap<Image2DG::Value>  grayShade(0, std::numeric_limits<Image2DG::Value>::max());
@@ -270,12 +276,12 @@ int main( int argc, char** argv )
     
     imagePtSup = Z2i::Point(image.domain().upperBound()[0],
                         image.domain().upperBound()[1]);
-    maxPosSliceZ = image.domain().upperBound()[1];
+    maxPosSliceZ = maxHeight;
     
     stringstream s;
     s << "3dHeightMapViewer - DGtalTools: ";
     string name = inputFileName.substr(inputFileName.find_last_of("/")+1,inputFileName.size()) ;
-    s << " " <<  name << " (W key to display settings)";
+    s << " " <<  name ;
     polyscope::options::programName = s.str();
     polyscope::options::buildGui=false;
     polyscope::options::groundPlaneMode = polyscope::GroundPlaneMode::None;

--- a/visualisation/3dHeightMapViewer.cpp
+++ b/visualisation/3dHeightMapViewer.cpp
@@ -157,7 +157,9 @@ int main( int argc, char** argv )
     Image2DCol imageTexture(image.domain());
     int maxHeight = (int)(std::numeric_limits<Image2DG::Value>::max()*scale);
     trace.info()<< "Max height from scale:" << maxHeight << std::endl;
-    
+    GradientColorMap<Image2DG::Value,CMAP_JET>  gradientShade( 0, std::numeric_limits<Image2DG::Value>::max());
+    GrayscaleColorMap<Image2DG::Value>  grayShade(0, std::numeric_limits<Image2DG::Value>::max());
+
     if(colorTextureImage != ""){
         imageTexture =  GenericReader<Image2DCol>::import( colorTextureImage );
     }
@@ -223,12 +225,16 @@ int main( int argc, char** argv )
     for (unsigned int i = 0; i < viewmesh.nbFaces(); i++){
         auto b =  viewmesh.getFaceBarycenter(i);
         auto bp = Z2i::Point(b[0], b[1]);
+        auto val = image(bp);
         if (image.domain().isInside(bp)){
-            if (colorTextureImage == "")
-                viewmesh.setFaceColor(i, DGtal::Color(image(bp)));
-            else
+            if(colorMap){
+                viewmesh.setFaceColor(i,gradientShade(val));
+            }else if (colorTextureImage != "") {
                 viewmesh.setFaceColor(i, DGtal::Color(imageTexture(bp)));
-
+            }else{
+                viewmesh.setFaceColor(i, grayShade(val));
+            }
+                        
         }
     }
     viewer.drawColor(Color(150,0,0,254));


### PR DESCRIPTION
# PR Description
Improve interface and display process (too slow with new DGTal 2.0 surfel display). 
It displays now the triangulated mesh of digital surfaces.
It also includes interface features from polyscope.
New preview will be integrated in the readme like:
 
<img width="1128" height="838" alt="Capture d’écran 2025-07-21 à 12 37 22" src="https://github.com/user-attachments/assets/6cf8efb0-cf95-4bbf-b920-a7b54ddf8378" />


# Checklist

- [ ] Doxygen documentation of the code completed (classes, methods, types, members...).
- [ ] Main tool doxygen documentation (following existing documentation of [DGtalTools documentation](http://dgtal.org/doc/tools/nightly/).
- [ ] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools/blob/master/CONTRIBUTING.md)
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools/blob/master/ChangeLog.md) added.
- [ ] Update the readme with potentially a screenshot of the tools if it applies. 
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Github Actions C.I. will fail).
- [ ] All continuous integration tests pass (Github Actions).
